### PR TITLE
fix: 상단 탭 바 진입 애니메이션 제거로 흰 seam 방지(#183)

### DIFF
--- a/products/templates/admin_home/base.html
+++ b/products/templates/admin_home/base.html
@@ -50,7 +50,10 @@
     <div class="ah-container">
       {# 상단 탭 + 로그아웃 바 — 페이지 전환(부분 로딩) 후에도 항상 유지되는 영역 #}
       {% block topbar %}
-      <header class="reveal reveal--fade" style="margin-bottom: var(--space-6); display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:var(--space-2);">
+      {# 상단 탭 바는 persistent shell — 진입 애니메이션(reveal)을 붙이지 않는다.
+         backdrop-filter(.glass-nav) 위에 will-change 레이어가 얹히면 초기 페인트 때
+         inset 하이라이트가 딱딱한 흰 seam으로 렌더되므로, 첫 프레임부터 안정적으로 그린다. #}
+      <header style="margin-bottom: var(--space-6); display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:var(--space-2);">
         <nav class="glass-nav" id="ah-topnav">
           <span class="glass-nav__indicator" aria-hidden="true"></span>
           <a class="glass-nav__item {% if request.resolver_match.url_name == 'admin_home' %}is-active{% endif %}" href="{% url 'admin_home' %}">Home</a>


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
reveal(will-change 레이어) 위 backdrop-filter의 inset 하이라이트가 초기 페인트 때 딱딱한 흰 선으로 렌더되던 문제 수정.
<!-- A clear and concise description about the feature -->

## 이슈
close #183
<!-- Add a issues that referenced this pull request -->
