### PR TITLE
Feat(be)/#187 ingredient modals

### DIFF
--- a/products/templates/admin_home/ingredient_list.html
+++ b/products/templates/admin_home/ingredient_list.html
@@ -1,8 +1,11 @@
 {% extends base_template|default:"admin_home/base.html" %}
 {% comment %}
-  원료 · 기능성 원료(Ingredient) 관리 — 목록/추가/삭제 + 상세 모달(조회·수정).
+  원료 · 기능성 원료(Ingredient) 관리 — 목록/추가/수정/삭제 (전부 모달).
   단일 뷰(ingredient_list)에서 POST action(create/update/delete)으로 분기한다.
-  · 목록 행의 "상세" 클릭 → 성분별 모달(효과/부작용 JSON 편집 + 성분 가이드 편집).
+  · 목록 헤더 ＋ 버튼 → 추가 모달(#ing-create-modal).
+  · 목록 항목 클릭 → 상세/수정 모달(#ing-modal-<id>), 삭제 버튼도 모달 안에.
+  · 모달은 #ah-subcontent 직속(비-transform 조상)에 두어 position:fixed 가 뷰포트 기준으로 동작하게 한다
+    (.reveal 등 transform/will-change 조상 안에 넣으면 중앙 정렬·오버레이가 깨진다).
   · 제품이 사용 중인 성분은 PROTECT 로 삭제가 막히며, 사용 중인 제품 수를 안내한다.
   리스트 편집 UI(효과/부작용/핵심 포인트/출처)는 제출 직전 JSON 배열로 직렬화된다.
 {% endcomment %}
@@ -14,215 +17,235 @@
 
 {# 서브내비 아래 영역 — 기능성/기타 전환 시 이 안쪽만 부분 교체된다(서브내비는 유지) #}
 <div id="ah-subcontent">
-<section class="glass-panel reveal" style="margin-bottom: var(--space-6);">
-  <p class="text-caption" style="color: var(--glass-highlight);">원료 관리</p>
-  <h1 class="text-title-lg">기능성 원료</h1>
-  <p class="text-body-sm" style="margin-top: var(--space-2); max-width: 52ch;">
-    기능성 원료(Ingredient)를 추가·삭제하고, 각 항목의 "상세"에서 효과·부작용과 성분 가이드를 편집합니다.
-    제품이 사용 중인 성분은 삭제할 수 없습니다.
-  </p>
-</section>
 
-<section class="glass-card reveal" style="margin-bottom: var(--space-6);">
-  <h2 class="text-title-sm">기능성 원료 추가</h2>
-  <form method="post" class="ah-recordbar">
-    {% csrf_token %}
-    <input type="hidden" name="action" value="create" />
-    <div class="ah-field">
-      <label class="ah-label" for="new-name">성분 이름</label>
-      <input class="ah-input" type="text" id="new-name" name="name"
-             placeholder="예: 비타민C" required />
-    </div>
-    <div class="ah-field">
-      <label class="ah-label" for="new-main">주성분</label>
-      <input class="ah-input" type="text" id="new-main" name="mainIngredient"
-             maxlength="100" placeholder="예: 아스코르브산" />
-    </div>
-    <div class="ah-field">
-      <label class="ah-label" for="new-min">최소 권장량</label>
-      <input class="ah-input" type="text" id="new-min" name="minRecommended"
-             maxlength="50" placeholder="예: 100mg" />
-    </div>
-    <div class="ah-field">
-      <label class="ah-label" for="new-max">최대 권장량</label>
-      <input class="ah-input" type="text" id="new-max" name="maxRecommended"
-             maxlength="50" placeholder="예: 1000mg" />
-    </div>
-    <button type="submit" class="btn btn-primary">추가</button>
-  </form>
-</section>
+  {# ── 모달들: #ah-subcontent 직속(비-transform)이라 fixed 위치가 뷰포트 기준으로 정상 동작 ── #}
 
-<section class="reveal">
-  <h2 class="text-title-sm" style="margin-bottom: var(--space-3);">
-    기능성 원료 목록 <span class="text-muted">({{ ingredients|length }})</span>
-  </h2>
-
-  {% if ingredients %}
-  <div class="ah-records" data-reveal-stagger>
-    {% for ing in ingredients %}
-    <div class="ah-record reveal">
-      <span class="ah-record__id text-body-sm">#{{ ing.id }}</span>
-
-      <div class="ah-record__edit" style="flex-wrap: wrap;">
-        <span class="text-body">{{ ing.name }}</span>
-        {% if ing.mainIngredient %}
-        <span class="text-body-sm text-muted">· {{ ing.mainIngredient }}</span>
-        {% endif %}
-        {% if ing.minRecommended or ing.maxRecommended %}
-        <span class="text-body-sm text-muted">
-          · 권장 {{ ing.minRecommended|default:"-" }} ~ {{ ing.maxRecommended|default:"-" }}
-        </span>
-        {% endif %}
+  {# 추가 모달 — 목록 헤더 ＋ 버튼으로 열림 #}
+  <div class="ah-modal" id="ing-create-modal" aria-hidden="true">
+    <div class="ah-modal__overlay" data-modal-close></div>
+    <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+         aria-labelledby="ing-create-modal-title">
+      <div class="ah-modal__head">
+        <h2 id="ing-create-modal-title" class="text-title-md">기능성 원료 추가</h2>
+        <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
       </div>
-
-      <div class="ah-record__actions">
-        <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">제품 {{ ing.product_count }}</span>
-        <button type="button" class="btn btn-glass" data-modal-open="ing-modal-{{ ing.id }}">상세</button>
-        {% if ing.product_count %}
-        {# 제품이 사용 중이면 PROTECT — 삭제 버튼을 비활성화하고 안내한다. #}
-        <button type="button" class="btn btn-danger" disabled
-                title="제품 {{ ing.product_count }}개에서 사용 중이라 삭제할 수 없습니다.">삭제</button>
-        {% else %}
-        <form method="post" onsubmit="return confirm('이 성분을 삭제할까요?');">
+      <div class="ah-modal__body">
+        <form method="post" class="ah-stack">
           {% csrf_token %}
-          <input type="hidden" name="action" value="delete" />
-          <input type="hidden" name="id" value="{{ ing.id }}" />
-          <button type="submit" class="btn btn-danger">삭제</button>
+          <input type="hidden" name="action" value="create" />
+          <div class="ah-field">
+            <label class="ah-label" for="new-name">성분 이름</label>
+            <input class="ah-input" type="text" id="new-name" name="name"
+                   placeholder="예: 비타민C" required />
+          </div>
+          <div class="ah-field">
+            <label class="ah-label" for="new-main">주성분</label>
+            <input class="ah-input" type="text" id="new-main" name="mainIngredient"
+                   maxlength="100" placeholder="예: 아스코르브산" />
+          </div>
+          <div style="display:flex; gap:var(--space-3); flex-wrap:wrap;">
+            <div class="ah-field" style="flex:1 1 160px;">
+              <label class="ah-label" for="new-min">최소 권장량</label>
+              <input class="ah-input" type="text" id="new-min" name="minRecommended"
+                     maxlength="50" placeholder="예: 100mg" />
+            </div>
+            <div class="ah-field" style="flex:1 1 160px;">
+              <label class="ah-label" for="new-max">최대 권장량</label>
+              <input class="ah-input" type="text" id="new-max" name="maxRecommended"
+                     maxlength="50" placeholder="예: 1000mg" />
+            </div>
+          </div>
+          <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
+            <button type="button" class="btn btn-glass" data-modal-close>취소</button>
+            <button type="submit" class="btn btn-primary">추가</button>
+          </div>
         </form>
-        {% endif %}
       </div>
     </div>
-
-    {# 성분 상세/수정 모달 — 목록 행의 "상세" 클릭 시 열림(interactions.js) #}
-    <div class="ah-modal" id="ing-modal-{{ ing.id }}" aria-hidden="true">
-      <div class="ah-modal__overlay" data-modal-close></div>
-      <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
-           aria-labelledby="ing-modal-{{ ing.id }}-title">
-        <div class="ah-modal__head">
-          <h2 id="ing-modal-{{ ing.id }}-title" class="text-title-md">성분 상세 · #{{ ing.id }}</h2>
-          <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
-        </div>
-        <div class="ah-modal__body">
-          <form method="post" data-ingredient-form class="ah-stack">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="update" />
-            <input type="hidden" name="id" value="{{ ing.id }}" />
-
-            <div class="ah-field">
-              <label class="ah-label">성분 이름</label>
-              <input class="ah-input" type="text" name="name" value="{{ ing.name }}"
-                     aria-label="성분 이름" required />
-            </div>
-            <div class="ah-field">
-              <label class="ah-label">주성분</label>
-              <input class="ah-input" type="text" name="mainIngredient" maxlength="100"
-                     value="{{ ing.mainIngredient|default:'' }}" aria-label="주성분" />
-            </div>
-            <div style="display:flex; gap:var(--space-3); flex-wrap:wrap;">
-              <div class="ah-field" style="flex:1 1 160px;">
-                <label class="ah-label">최소 권장량</label>
-                <input class="ah-input" type="text" name="minRecommended" maxlength="50"
-                       value="{{ ing.minRecommended|default:'' }}" aria-label="최소 권장량" />
-              </div>
-              <div class="ah-field" style="flex:1 1 160px;">
-                <label class="ah-label">최대 권장량</label>
-                <input class="ah-input" type="text" name="maxRecommended" maxlength="50"
-                       value="{{ ing.maxRecommended|default:'' }}" aria-label="최대 권장량" />
-              </div>
-            </div>
-
-            {# 효과 (JSON 리스트) #}
-            <div class="ah-field">
-              <label class="ah-label">효과</label>
-              <div class="ah-listedit" data-listedit>
-                <div class="ah-listedit__rows">
-                  {% for e in ing.effect %}
-                  <div class="ah-listedit__row">
-                    <textarea class="ah-textarea text-body" data-listedit-item
-                              rows="2" aria-label="효과 항목">{{ e }}</textarea>
-                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                  </div>
-                  {% endfor %}
-                </div>
-                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-                <input type="hidden" name="effect" data-listedit-target />
-              </div>
-            </div>
-
-            {# 부작용 (JSON 리스트) #}
-            <div class="ah-field">
-              <label class="ah-label">부작용</label>
-              <div class="ah-listedit" data-listedit>
-                <div class="ah-listedit__rows">
-                  {% for s in ing.sideEffect %}
-                  <div class="ah-listedit__row">
-                    <textarea class="ah-textarea text-body" data-listedit-item
-                              rows="2" aria-label="부작용 항목">{{ s }}</textarea>
-                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                  </div>
-                  {% endfor %}
-                </div>
-                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-                <input type="hidden" name="sideEffect" data-listedit-target />
-              </div>
-            </div>
-
-            {# 성분 가이드(IngredientGuide, 1:1) — 핵심 포인트 / 출처 #}
-            <div class="ah-formsection">
-              <h3 class="text-title-sm">성분 가이드</h3>
-              <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
-                성분별 핵심 포인트와 출처를 관리합니다. (저장 시 없으면 자동 생성)
-              </p>
-            </div>
-
-            <div class="ah-field">
-              <label class="ah-label">핵심 포인트</label>
-              <div class="ah-listedit" data-listedit>
-                <div class="ah-listedit__rows">
-                  {% for kp in ing.guide.keyPoints %}
-                  <div class="ah-listedit__row">
-                    <textarea class="ah-textarea text-body" data-listedit-item
-                              rows="2" aria-label="핵심 포인트 항목">{{ kp }}</textarea>
-                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                  </div>
-                  {% endfor %}
-                </div>
-                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-                <input type="hidden" name="keyPoints" data-listedit-target />
-              </div>
-            </div>
-
-            <div class="ah-field">
-              <label class="ah-label">출처</label>
-              <div class="ah-listedit" data-listedit>
-                <div class="ah-listedit__rows">
-                  {% for src in ing.guide.sources %}
-                  <div class="ah-listedit__row">
-                    <textarea class="ah-textarea text-body" data-listedit-item
-                              rows="2" aria-label="출처 항목">{{ src }}</textarea>
-                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                  </div>
-                  {% endfor %}
-                </div>
-                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-                <input type="hidden" name="sources" data-listedit-target />
-              </div>
-            </div>
-
-            <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
-              <button type="button" class="btn btn-glass" data-modal-close>취소</button>
-              <button type="submit" class="btn btn-primary">저장</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-    {% endfor %}
   </div>
-  {% else %}
-  <p class="ah-record-empty text-body">등록된 기능성 원료가 없습니다. 위에서 첫 성분을 추가해보세요.</p>
-  {% endif %}
-</section>
+
+  {# 상세/수정 모달 — 목록 항목 클릭 시 열림. 효과/부작용/가이드 편집 + 삭제. #}
+  {% for ing in ingredients %}
+  <div class="ah-modal" id="ing-modal-{{ ing.id }}" aria-hidden="true">
+    <div class="ah-modal__overlay" data-modal-close></div>
+    <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+         aria-labelledby="ing-modal-{{ ing.id }}-title">
+      <div class="ah-modal__head">
+        <h2 id="ing-modal-{{ ing.id }}-title" class="text-title-md">성분 상세 · #{{ ing.id }}</h2>
+        <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
+      </div>
+      <div class="ah-modal__body">
+        <form method="post" data-ingredient-form class="ah-stack">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="update" />
+          <input type="hidden" name="id" value="{{ ing.id }}" />
+
+          <div class="ah-field">
+            <label class="ah-label">성분 이름</label>
+            <input class="ah-input" type="text" name="name" value="{{ ing.name }}"
+                   aria-label="성분 이름" required />
+          </div>
+          <div class="ah-field">
+            <label class="ah-label">주성분</label>
+            <input class="ah-input" type="text" name="mainIngredient" maxlength="100"
+                   value="{{ ing.mainIngredient|default:'' }}" aria-label="주성분" />
+          </div>
+          <div style="display:flex; gap:var(--space-3); flex-wrap:wrap;">
+            <div class="ah-field" style="flex:1 1 160px;">
+              <label class="ah-label">최소 권장량</label>
+              <input class="ah-input" type="text" name="minRecommended" maxlength="50"
+                     value="{{ ing.minRecommended|default:'' }}" aria-label="최소 권장량" />
+            </div>
+            <div class="ah-field" style="flex:1 1 160px;">
+              <label class="ah-label">최대 권장량</label>
+              <input class="ah-input" type="text" name="maxRecommended" maxlength="50"
+                     value="{{ ing.maxRecommended|default:'' }}" aria-label="최대 권장량" />
+            </div>
+          </div>
+
+          {# 효과 (JSON 리스트) #}
+          <div class="ah-field">
+            <label class="ah-label">효과</label>
+            <div class="ah-listedit" data-listedit>
+              <div class="ah-listedit__rows">
+                {% for e in ing.effect %}
+                <div class="ah-listedit__row">
+                  <textarea class="ah-textarea text-body" data-listedit-item
+                            rows="2" aria-label="효과 항목">{{ e }}</textarea>
+                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                </div>
+                {% endfor %}
+              </div>
+              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+              <input type="hidden" name="effect" data-listedit-target />
+            </div>
+          </div>
+
+          {# 부작용 (JSON 리스트) #}
+          <div class="ah-field">
+            <label class="ah-label">부작용</label>
+            <div class="ah-listedit" data-listedit>
+              <div class="ah-listedit__rows">
+                {% for s in ing.sideEffect %}
+                <div class="ah-listedit__row">
+                  <textarea class="ah-textarea text-body" data-listedit-item
+                            rows="2" aria-label="부작용 항목">{{ s }}</textarea>
+                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                </div>
+                {% endfor %}
+              </div>
+              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+              <input type="hidden" name="sideEffect" data-listedit-target />
+            </div>
+          </div>
+
+          {# 성분 가이드(IngredientGuide, 1:1) — 핵심 포인트 / 출처 #}
+          <div class="ah-formsection">
+            <h3 class="text-title-sm">성분 가이드</h3>
+            <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
+              성분별 핵심 포인트와 출처를 관리합니다. (저장 시 없으면 자동 생성)
+            </p>
+          </div>
+
+          <div class="ah-field">
+            <label class="ah-label">핵심 포인트</label>
+            <div class="ah-listedit" data-listedit>
+              <div class="ah-listedit__rows">
+                {% for kp in ing.guide.keyPoints %}
+                <div class="ah-listedit__row">
+                  <textarea class="ah-textarea text-body" data-listedit-item
+                            rows="2" aria-label="핵심 포인트 항목">{{ kp }}</textarea>
+                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                </div>
+                {% endfor %}
+              </div>
+              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+              <input type="hidden" name="keyPoints" data-listedit-target />
+            </div>
+          </div>
+
+          <div class="ah-field">
+            <label class="ah-label">출처</label>
+            <div class="ah-listedit" data-listedit>
+              <div class="ah-listedit__rows">
+                {% for src in ing.guide.sources %}
+                <div class="ah-listedit__row">
+                  <textarea class="ah-textarea text-body" data-listedit-item
+                            rows="2" aria-label="출처 항목">{{ src }}</textarea>
+                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                </div>
+                {% endfor %}
+              </div>
+              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+              <input type="hidden" name="sources" data-listedit-target />
+            </div>
+          </div>
+
+          <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
+            <button type="button" class="btn btn-glass" data-modal-close>취소</button>
+            <button type="submit" class="btn btn-primary">저장</button>
+          </div>
+        </form>
+
+        {# 삭제 — update 폼과 중첩되지 않도록 별도 폼. PROTECT 시 비활성화. #}
+        <div style="margin-top: var(--space-4); padding-top: var(--space-3); border-top: 1px solid var(--glass-border); display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap;">
+          <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">사용 중 제품 {{ ing.product_count }}</span>
+          {% if ing.product_count %}
+          <button type="button" class="btn btn-danger" disabled
+                  title="제품 {{ ing.product_count }}개에서 사용 중이라 삭제할 수 없습니다.">삭제</button>
+          {% else %}
+          <form method="post" onsubmit="return confirm('이 성분을 삭제할까요?');">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="delete" />
+            <input type="hidden" name="id" value="{{ ing.id }}" />
+            <button type="submit" class="btn btn-danger">이 성분 삭제</button>
+          </form>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+
+  {# ── 목록 ── #}
+  <section class="reveal">
+    <div style="display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3);">
+      <h2 class="text-title-sm">
+        기능성 원료 목록 <span class="text-muted">({{ ingredients|length }})</span>
+      </h2>
+      <button type="button" class="btn btn-primary" data-modal-open="ing-create-modal"
+              title="기능성 원료 추가" aria-label="기능성 원료 추가">＋</button>
+    </div>
+
+    {% if ingredients %}
+    <div class="ah-records" data-reveal-stagger>
+      {% for ing in ingredients %}
+      <div class="ah-record reveal" data-modal-open="ing-modal-{{ ing.id }}"
+           style="cursor:pointer;" title="클릭하여 상세·수정">
+        <span class="ah-record__id text-body-sm">#{{ ing.id }}</span>
+
+        <div class="ah-record__edit" style="flex-wrap: wrap;">
+          <span class="text-body">{{ ing.name }}</span>
+          {% if ing.mainIngredient %}
+          <span class="text-body-sm text-muted">· {{ ing.mainIngredient }}</span>
+          {% endif %}
+          {% if ing.minRecommended or ing.maxRecommended %}
+          <span class="text-body-sm text-muted">
+            · 권장 {{ ing.minRecommended|default:"-" }} ~ {{ ing.maxRecommended|default:"-" }}
+          </span>
+          {% endif %}
+        </div>
+
+        <div class="ah-record__actions">
+          <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">제품 {{ ing.product_count }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="ah-record-empty text-body">등록된 기능성 원료가 없습니다. 위 ＋ 로 첫 성분을 추가해보세요.</p>
+    {% endif %}
+  </section>
 </div>
 {% endblock %}
 

--- a/products/templates/admin_home/ingredient_other.html
+++ b/products/templates/admin_home/ingredient_other.html
@@ -1,10 +1,12 @@
 {% extends base_template|default:"admin_home/base.html" %}
 {% comment %}
-  원료 · 기타 원료(OtherIngredient) 관리 — 목록/추가/수정/삭제.
+  원료 · 기타 원료(OtherIngredient) 관리 — 목록/추가/수정/삭제 (전부 모달, 기능성 원료와 통일).
   단일 뷰(ingredient_other)에서 POST action(create/update/delete)으로 분기한다.
-  이름 한 필드만 있는 단순 모델이라 상세 모달 없이 인라인 수정 폼(ah-record__edit)을 쓴다.
-  ProductOtherIngredient.other_ingredient 는 PROTECT 이므로, 제품이 사용 중인
-  기타 원료는 삭제 버튼을 비활성화하고 사용 중인 제품 수를 안내한다.
+  · 목록 헤더 ＋ 버튼 → 추가 모달(#oi-create-modal).
+  · 목록 항목 클릭 → 수정 모달(#oi-modal-<id>), 삭제 버튼도 모달 안에.
+  · 모달은 #ah-subcontent 직속(비-transform)에 두어 position:fixed 가 뷰포트 기준으로 동작하게 한다.
+  ProductOtherIngredient.other_ingredient 는 PROTECT 이므로, 제품이 사용 중인 기타 원료는
+  삭제 버튼을 비활성화하고 사용 중인 제품 수를 안내한다.
 {% endcomment %}
 
 {% block title %}원료 · 기타 원료 · DASII{% endblock %}
@@ -14,70 +16,108 @@
 
 {# 서브내비 아래 영역 — 기능성/기타 전환 시 이 안쪽만 부분 교체된다(서브내비는 유지) #}
 <div id="ah-subcontent">
-<section class="glass-panel reveal" style="margin-bottom: var(--space-6);">
-  <p class="text-caption" style="color: var(--glass-highlight);">원료 관리</p>
-  <h1 class="text-title-lg">기타 원료</h1>
-  <p class="text-body-sm" style="margin-top: var(--space-2); max-width: 52ch;">
-    기타 원료(Other Ingredient)를 추가·수정·삭제합니다.
-    제품이 사용 중인 기타 원료는 삭제할 수 없습니다.
-  </p>
-</section>
 
-<section class="glass-card reveal" style="margin-bottom: var(--space-6);">
-  <h2 class="text-title-sm">기타 원료 추가</h2>
-  <form method="post" class="ah-recordbar">
-    {% csrf_token %}
-    <input type="hidden" name="action" value="create" />
-    <div class="ah-field">
-      <label class="ah-label" for="new-name">기타 원료 이름</label>
-      <input class="ah-input" type="text" id="new-name" name="name"
-             maxlength="255" placeholder="예: 정제수" required />
-    </div>
-    <button type="submit" class="btn btn-primary">추가</button>
-  </form>
-</section>
-
-<section class="reveal">
-  <h2 class="text-title-sm" style="margin-bottom: var(--space-3);">
-    기타 원료 목록 <span class="text-muted">({{ others|length }})</span>
-  </h2>
-
-  {% if others %}
-  <div class="ah-records" data-reveal-stagger>
-    {% for oi in others %}
-    <div class="ah-record reveal">
-      <span class="ah-record__id text-body-sm">#{{ oi.id }}</span>
-
-      <form method="post" class="ah-record__edit">
-        {% csrf_token %}
-        <input type="hidden" name="action" value="update" />
-        <input type="hidden" name="id" value="{{ oi.id }}" />
-        <input class="ah-input" type="text" name="name" value="{{ oi.name }}"
-               maxlength="255" aria-label="기타 원료 이름" required />
-        <button type="submit" class="btn btn-glass">수정</button>
-      </form>
-
-      <div class="ah-record__actions">
-        <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">제품 {{ oi.product_count }}</span>
-        {% if oi.product_count %}
-        {# 제품이 사용 중이면 PROTECT — 삭제 버튼을 비활성화하고 안내한다. #}
-        <button type="button" class="btn btn-danger" disabled
-                title="제품 {{ oi.product_count }}개에서 사용 중이라 삭제할 수 없습니다.">삭제</button>
-        {% else %}
-        <form method="post" onsubmit="return confirm('이 기타 원료를 삭제할까요?');">
+  {# 추가 모달 — 목록 헤더 ＋ 버튼으로 열림 #}
+  <div class="ah-modal" id="oi-create-modal" aria-hidden="true">
+    <div class="ah-modal__overlay" data-modal-close></div>
+    <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+         aria-labelledby="oi-create-modal-title">
+      <div class="ah-modal__head">
+        <h2 id="oi-create-modal-title" class="text-title-md">기타 원료 추가</h2>
+        <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
+      </div>
+      <div class="ah-modal__body">
+        <form method="post" class="ah-stack">
           {% csrf_token %}
-          <input type="hidden" name="action" value="delete" />
-          <input type="hidden" name="id" value="{{ oi.id }}" />
-          <button type="submit" class="btn btn-danger">삭제</button>
+          <input type="hidden" name="action" value="create" />
+          <div class="ah-field">
+            <label class="ah-label" for="new-name">기타 원료 이름</label>
+            <input class="ah-input" type="text" id="new-name" name="name"
+                   maxlength="255" placeholder="예: 정제수" required />
+          </div>
+          <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
+            <button type="button" class="btn btn-glass" data-modal-close>취소</button>
+            <button type="submit" class="btn btn-primary">추가</button>
+          </div>
         </form>
-        {% endif %}
       </div>
     </div>
-    {% endfor %}
   </div>
-  {% else %}
-  <p class="ah-record-empty text-body">등록된 기타 원료가 없습니다. 위에서 첫 기타 원료를 추가해보세요.</p>
-  {% endif %}
-</section>
+
+  {# 수정/삭제 모달 — 목록 항목 클릭 시 열림 #}
+  {% for oi in others %}
+  <div class="ah-modal" id="oi-modal-{{ oi.id }}" aria-hidden="true">
+    <div class="ah-modal__overlay" data-modal-close></div>
+    <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+         aria-labelledby="oi-modal-{{ oi.id }}-title">
+      <div class="ah-modal__head">
+        <h2 id="oi-modal-{{ oi.id }}-title" class="text-title-md">기타 원료 · #{{ oi.id }}</h2>
+        <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
+      </div>
+      <div class="ah-modal__body">
+        <form method="post" class="ah-stack">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="update" />
+          <input type="hidden" name="id" value="{{ oi.id }}" />
+          <div class="ah-field">
+            <label class="ah-label">기타 원료 이름</label>
+            <input class="ah-input" type="text" name="name" value="{{ oi.name }}"
+                   maxlength="255" aria-label="기타 원료 이름" required />
+          </div>
+          <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
+            <button type="button" class="btn btn-glass" data-modal-close>취소</button>
+            <button type="submit" class="btn btn-primary">저장</button>
+          </div>
+        </form>
+
+        {# 삭제 — update 폼과 중첩되지 않도록 별도 폼. PROTECT 시 비활성화. #}
+        <div style="margin-top: var(--space-4); padding-top: var(--space-3); border-top: 1px solid var(--glass-border); display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap;">
+          <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">사용 중 제품 {{ oi.product_count }}</span>
+          {% if oi.product_count %}
+          <button type="button" class="btn btn-danger" disabled
+                  title="제품 {{ oi.product_count }}개에서 사용 중이라 삭제할 수 없습니다.">삭제</button>
+          {% else %}
+          <form method="post" onsubmit="return confirm('이 기타 원료를 삭제할까요?');">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="delete" />
+            <input type="hidden" name="id" value="{{ oi.id }}" />
+            <button type="submit" class="btn btn-danger">이 기타 원료 삭제</button>
+          </form>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+
+  {# ── 목록 ── #}
+  <section class="reveal">
+    <div style="display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3);">
+      <h2 class="text-title-sm">
+        기타 원료 목록 <span class="text-muted">({{ others|length }})</span>
+      </h2>
+      <button type="button" class="btn btn-primary" data-modal-open="oi-create-modal"
+              title="기타 원료 추가" aria-label="기타 원료 추가">＋</button>
+    </div>
+
+    {% if others %}
+    <div class="ah-records" data-reveal-stagger>
+      {% for oi in others %}
+      <div class="ah-record reveal" data-modal-open="oi-modal-{{ oi.id }}"
+           style="cursor:pointer;" title="클릭하여 수정">
+        <span class="ah-record__id text-body-sm">#{{ oi.id }}</span>
+        <div class="ah-record__edit" style="flex-wrap: wrap;">
+          <span class="text-body">{{ oi.name }}</span>
+        </div>
+        <div class="ah-record__actions">
+          <span class="ah-badge ah-badge--neutral" title="사용 중인 제품 수">제품 {{ oi.product_count }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="ah-record-empty text-body">등록된 기타 원료가 없습니다. 위 ＋ 로 첫 기타 원료를 추가해보세요.</p>
+    {% endif %}
+  </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
기능성 원료·기타 원료 관리 UI를 인라인 폼에서 모달 기반으로 통일.
- 목록 헤더 ＋ 버튼 → 추가 모달
- 목록 항목 클릭 → 상세/수정 모달(삭제 버튼도 모달 안으로)
- 모달을 #ah-subcontent 직속(비-transform 조상)에 두어 position:fixed 중앙 정렬 버그 수정
<!-- A clear and concise description about the feature -->

## 이슈
close #187 
<!-- Add a issues that referenced this pull request -->
