### PR TITLE
fix: 제품 추가 시 성분/기타원료/카테고리 중복 연결 방지(#189)

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -593,46 +593,53 @@ def product_list(request):
                         upload_images_to_s3(product, image_files)
                     )
 
-                # 성분 + 용량 → ProductIngredient
+                # 성분 + 용량 → ProductIngredient (같은 성분 중복 선택 시 unique 위반 방지)
                 ingredient_ids = request.POST.getlist("ingredient_ids[]")
                 amounts = request.POST.getlist("amounts[]")
+                seen_ing = set()
                 for ingredient_id, amount in zip(ingredient_ids, amounts):
                     ingredient_id = ingredient_id.strip()
                     amount = amount.strip()
-                    if ingredient_id and amount:
-                        try:
-                            ingredient = Ingredient.objects.get(id=ingredient_id)
-                        except (Ingredient.DoesNotExist, ValueError):
-                            continue
-                        ProductIngredient.objects.create(
-                            product=product,
-                            ingredient=ingredient,
-                            amount=amount,
-                        )
+                    if not (ingredient_id and amount) or ingredient_id in seen_ing:
+                        continue
+                    try:
+                        ingredient = Ingredient.objects.get(id=ingredient_id)
+                    except (Ingredient.DoesNotExist, ValueError):
+                        continue
+                    seen_ing.add(ingredient_id)
+                    ProductIngredient.objects.create(
+                        product=product,
+                        ingredient=ingredient,
+                        amount=amount,
+                    )
 
-                # 기타 원료 → ProductOtherIngredient
+                # 기타 원료 → ProductOtherIngredient (같은 원료 중복 선택 시 unique 위반 방지)
+                seen_oi = set()
                 for oi_id in request.POST.getlist("other_ingredient_ids[]"):
                     oi_id = oi_id.strip()
-                    if not oi_id:
+                    if not oi_id or oi_id in seen_oi:
                         continue
                     try:
                         oi = OtherIngredient.objects.get(id=oi_id)
                     except (OtherIngredient.DoesNotExist, ValueError):
                         continue
+                    seen_oi.add(oi_id)
                     ProductOtherIngredient.objects.create(
                         product=product,
                         other_ingredient=oi,
                     )
 
-                # 소분류 카테고리 → CategoryProduct
+                # 소분류 카테고리 → CategoryProduct (같은 카테고리 중복 선택 시 unique 위반 방지)
+                seen_cat = set()
                 for category_id in request.POST.getlist("category_ids[]"):
                     category_id = category_id.strip()
-                    if not category_id:
+                    if not category_id or category_id in seen_cat:
                         continue
                     try:
                         category = SmallCategory.objects.get(id=category_id)
                     except (SmallCategory.DoesNotExist, ValueError):
                         continue
+                    seen_cat.add(category_id)
                     CategoryProduct.objects.create(
                         product=product,
                         category=category,


### PR DESCRIPTION
제출된 id 중복을 dedupe(seen set)해 ProductOtherIngredient 등의 unique(product, *) 제약 위반(duplicate key) 오류를 막는다.

<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
제품 추가 폼 제출 시 같은 성분/기타원료/카테고리를 중복 선택하는 경우를 dedupe(seen set)하여
중복 연결 생성을 방지.
<!-- A clear and concise description about the feature -->

## 이슈

<!-- Add a issues that referenced this pull request -->
