### PR TITLE
Feat(be)/#190 category mindmap

### DIFF
--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -517,7 +517,7 @@ body.ah-modal-open { overflow: hidden; }
 .ah-map {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-6);
 }
 .ah-map__group {
   display: grid;

--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -510,67 +510,75 @@
 body.ah-modal-open { overflow: hidden; }
 
 /* =========================================================
-   Category Tree — 대/중/소 항상 펼침 중첩 트리 (옵시디언 탐색기 톤)
-   커넥터선: 자식 컨테이너의 세로 가이드(border-left) + 각 행의 가로 tick(::before).
-   색/여백은 전부 토큰. 노드 액션은 hover/focus-within 시 노출(18px floor 준수).
+   Category Map — 대/중/소 3열 마인드맵
+   1col 대분류 · 2col 중분류 · 3col 소분류. 열 간 커넥터는 border-left 세로선.
+   대분류는 자기 중분류 묶음에 세로 중앙 정렬. 색/여백 전부 토큰, 18px floor 준수.
    ========================================================= */
-.ah-tree,
-.ah-tree ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.ah-map {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
 }
-.ah-tree__children {
-  margin-left: var(--space-4);
+.ah-map__group {
+  display: grid;
+  grid-template-columns: minmax(150px, 220px) 1fr;
+  align-items: center;
+  gap: var(--space-4);
+}
+.ah-map__branches {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  border-left: 2px solid var(--glass-border); /* 대 → 중 커넥터 */
+  padding-left: var(--space-4);
+}
+.ah-map__branch {
+  display: grid;
+  grid-template-columns: minmax(140px, 200px) 1fr;
+  align-items: center;
+  gap: var(--space-3);
+}
+.ah-map__smalls {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: var(--space-2);
+  border-left: 2px solid var(--glass-border); /* 중 → 소 커넥터 */
   padding-left: var(--space-3);
-  border-left: 1px solid var(--glass-border);
 }
-.ah-tree__item {
-  position: relative;
-}
-.ah-tree__row {
+.ah-map__node {
   position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
   transition: background var(--transition-base);
 }
-.ah-tree__row:hover {
-  background: var(--glass-bg);
+.ah-map__node--big {
+  background: var(--glass-bg-strong);
 }
-/* 자식 행/빈 안내 앞의 짧은 가로 커넥터 tick */
-.ah-tree__children > .ah-tree__item > .ah-tree__row::before,
-.ah-tree__children > .ah-tree__empty::before {
-  content: "";
-  position: absolute;
-  left: calc(var(--space-3) * -1);
-  top: 50%;
-  width: var(--space-3);
-  height: 1px;
-  background: var(--glass-border);
+.ah-map__node:hover {
+  background: var(--glass-bg-strong);
 }
-.ah-tree__icon {
-  flex: none;
-  font-size: var(--fs-text-sm); /* 18px floor */
-  line-height: 1;
-}
-.ah-tree__name {
+.ah-map__name {
   font-weight: var(--font-weight-bold);
 }
-.ah-tree__actions {
+.ah-map__actions {
   display: inline-flex;
   gap: var(--space-1);
-  margin-left: var(--space-2);
+  margin-left: auto;
+  padding-left: var(--space-2);
   opacity: 0;
   transition: opacity var(--transition-base);
 }
-.ah-tree__row:hover .ah-tree__actions,
-.ah-tree__row:focus-within .ah-tree__actions {
+.ah-map__node:hover .ah-map__actions,
+.ah-map__node:focus-within .ah-map__actions {
   opacity: 1;
 }
-.ah-tree__btn {
+.ah-map__btn {
   flex: none;
   min-width: 34px;
   height: 34px;
@@ -589,15 +597,14 @@ body.ah-modal-open { overflow: hidden; }
     background var(--transition-base),
     border-color var(--transition-base);
 }
-.ah-tree__btn:hover {
+.ah-map__btn:hover {
   background: var(--glass-bg-strong);
   border-color: var(--glass-border-strong);
 }
-.ah-tree__btn--danger {
+.ah-map__btn--danger {
   color: var(--color-error);
 }
-.ah-tree__empty {
-  position: relative;
-  padding: var(--space-1) var(--space-2);
+.ah-map__empty {
   color: var(--glass-highlight);
+  padding: var(--space-1) var(--space-2);
 }

--- a/products/templates/admin_home/category_tree.html
+++ b/products/templates/admin_home/category_tree.html
@@ -21,87 +21,86 @@
   </div>
   <button type="button" class="btn btn-primary"
           data-modal-open="category-modal"
-          data-cat-act="create" data-cat-level="big" data-cat-title="대분류 추가">
-    ＋ 대분류 추가
-  </button>
+          data-cat-act="create" data-cat-level="big" data-cat-title="대분류 추가"
+          title="대분류 추가" aria-label="대분류 추가">＋</button>
 </section>
 
 <section class="reveal">
   {% if bigs %}
-  <ul class="ah-tree">
+  {# 3열 마인드맵 — 1col 대분류 · 2col 중분류 · 3col 소분류, 열 간 커넥터로 연결 #}
+  <div class="ah-map">
     {% for big in bigs %}
-    <li class="ah-tree__item">
-      <div class="ah-tree__row ah-tree__row--big">
-        <span class="ah-tree__icon" aria-hidden="true">📁</span>
-        <span class="ah-tree__name text-body">{{ big.category }}</span>
-        <span class="ah-tree__actions">
-          <button type="button" class="ah-tree__btn" title="중분류 추가"
+    <div class="ah-map__group">
+      {# col 1 — 대분류 (자기 중분류 묶음에 세로 중앙) #}
+      <div class="ah-map__node ah-map__node--big">
+        <span class="ah-map__name text-body">{{ big.category }}</span>
+        <span class="ah-map__actions">
+          <button type="button" class="ah-map__btn" title="중분류 추가"
                   data-modal-open="category-modal"
                   data-cat-act="create" data-cat-level="middle" data-cat-parent="{{ big.id }}"
                   data-cat-title="중분류 추가">＋</button>
-          <button type="button" class="ah-tree__btn" title="이름 수정"
+          <button type="button" class="ah-map__btn" title="이름 수정"
                   data-modal-open="category-modal"
                   data-cat-act="update" data-cat-level="big" data-cat-id="{{ big.id }}"
                   data-cat-name="{{ big.category }}" data-cat-title="대분류 수정">✎</button>
-          <button type="button" class="ah-tree__btn ah-tree__btn--danger" title="삭제"
+          <button type="button" class="ah-map__btn ah-map__btn--danger" title="삭제"
                   data-cat-act="delete" data-cat-level="big" data-cat-id="{{ big.id }}"
                   data-cat-confirm="이 대분류와 하위 중·소분류, 제품 연결이 모두 삭제됩니다. 계속할까요?">🗑</button>
         </span>
       </div>
 
-      <ul class="ah-tree__children">
+      {# col 2+3 — 중분류별 행: [중분류] [소분류들] #}
+      <div class="ah-map__branches">
         {% for mid in big.middle_categories.all %}
-        <li class="ah-tree__item">
-          <div class="ah-tree__row ah-tree__row--middle">
-            <span class="ah-tree__icon" aria-hidden="true">📂</span>
-            <span class="ah-tree__name text-body">{{ mid.category }}</span>
-            <span class="ah-tree__actions">
-              <button type="button" class="ah-tree__btn" title="소분류 추가"
+        <div class="ah-map__branch">
+          <div class="ah-map__node ah-map__node--mid">
+            <span class="ah-map__name text-body">{{ mid.category }}</span>
+            <span class="ah-map__actions">
+              <button type="button" class="ah-map__btn" title="소분류 추가"
                       data-modal-open="category-modal"
                       data-cat-act="create" data-cat-level="small" data-cat-parent="{{ mid.id }}"
                       data-cat-title="소분류 추가">＋</button>
-              <button type="button" class="ah-tree__btn" title="이름 수정"
+              <button type="button" class="ah-map__btn" title="이름 수정"
                       data-modal-open="category-modal"
                       data-cat-act="update" data-cat-level="middle" data-cat-id="{{ mid.id }}"
                       data-cat-name="{{ mid.category }}" data-cat-title="중분류 수정">✎</button>
-              <button type="button" class="ah-tree__btn ah-tree__btn--danger" title="삭제"
+              <button type="button" class="ah-map__btn ah-map__btn--danger" title="삭제"
                       data-cat-act="delete" data-cat-level="middle" data-cat-id="{{ mid.id }}"
                       data-cat-confirm="이 중분류와 하위 소분류, 제품 연결이 모두 삭제됩니다. 계속할까요?">🗑</button>
             </span>
           </div>
 
-          <ul class="ah-tree__children">
+          <div class="ah-map__smalls">
             {% for small in mid.small_categories.all %}
-            <li class="ah-tree__item">
-              <div class="ah-tree__row ah-tree__row--small">
-                <span class="ah-tree__icon" aria-hidden="true">📄</span>
-                <span class="ah-tree__name text-body">{{ small.category }}</span>
-                <span class="ah-badge ah-badge--neutral" title="연결된 제품 수">제품 {{ small.product_count }}</span>
-                <span class="ah-tree__actions">
-                  <button type="button" class="ah-tree__btn" title="이름 수정"
-                          data-modal-open="category-modal"
-                          data-cat-act="update" data-cat-level="small" data-cat-id="{{ small.id }}"
-                          data-cat-name="{{ small.category }}" data-cat-title="소분류 수정">✎</button>
-                  <button type="button" class="ah-tree__btn ah-tree__btn--danger" title="삭제"
-                          data-cat-act="delete" data-cat-level="small" data-cat-id="{{ small.id }}"
-                          data-cat-confirm="이 소분류와 제품 연결이 삭제됩니다. 계속할까요?">🗑</button>
-                </span>
-              </div>
-            </li>
+            <div class="ah-map__node ah-map__node--small">
+              <span class="ah-map__name text-body">{{ small.category }}</span>
+              <span class="ah-badge ah-badge--neutral" title="연결된 제품 수">{{ small.product_count }}</span>
+              <span class="ah-map__actions">
+                <button type="button" class="ah-map__btn" title="이름 수정"
+                        data-modal-open="category-modal"
+                        data-cat-act="update" data-cat-level="small" data-cat-id="{{ small.id }}"
+                        data-cat-name="{{ small.category }}" data-cat-title="소분류 수정">✎</button>
+                <button type="button" class="ah-map__btn ah-map__btn--danger" title="삭제"
+                        data-cat-act="delete" data-cat-level="small" data-cat-id="{{ small.id }}"
+                        data-cat-confirm="이 소분류와 제품 연결이 삭제됩니다. 계속할까요?">🗑</button>
+              </span>
+            </div>
             {% empty %}
-            <li class="ah-tree__empty text-body-sm">소분류가 없습니다.</li>
+            <div class="ah-map__empty text-body-sm">소분류 없음</div>
             {% endfor %}
-          </ul>
-        </li>
+          </div>
+        </div>
         {% empty %}
-        <li class="ah-tree__empty text-body-sm">중분류가 없습니다.</li>
+        <div class="ah-map__branch">
+          <div class="ah-map__empty text-body-sm">중분류 없음</div>
+        </div>
         {% endfor %}
-      </ul>
-    </li>
+      </div>
+    </div>
     {% endfor %}
-  </ul>
+  </div>
   {% else %}
-  <p class="ah-record-empty text-body">등록된 대분류가 없습니다. 위 "대분류 추가"로 시작하세요.</p>
+  <p class="ah-record-empty text-body">등록된 대분류가 없습니다. 위 ＋ 로 시작하세요.</p>
   {% endif %}
 </section>
 


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
카테고리 트리(.ah-tree)를 3열 마인드맵(.ah-map) 레이아웃으로 완전 교체.
1열 대분류 · 2열 중분류 · 3열 소분류, 열 간 커넥터 선으로 연결.
(#185의 .ah-tree 들여쓰기 CSS 버그가 이 교체로 자연히 해소됨)
<!-- A clear and concise description about the feature -->

## 이슈
close #190 
<!-- Add a issues that referenced this pull request -->
