### PR TITLE
fix: 상단 바 여러 줄 {# #} 주석이 화면에 렌더되던 문제 수정(#208)

### DIFF
--- a/products/templates/admin_home/base.html
+++ b/products/templates/admin_home/base.html
@@ -50,9 +50,11 @@
     <div class="ah-container">
       {# 상단 탭 + 로그아웃 바 — 페이지 전환(부분 로딩) 후에도 항상 유지되는 영역 #}
       {% block topbar %}
-      {# 상단 탭 바는 persistent shell — 진입 애니메이션(reveal)을 붙이지 않는다.
-         backdrop-filter(.glass-nav) 위에 will-change 레이어가 얹히면 초기 페인트 때
-         inset 하이라이트가 딱딱한 흰 seam으로 렌더되므로, 첫 프레임부터 안정적으로 그린다. #}
+      {% comment %}
+        상단 탭 바는 persistent shell — 진입 애니메이션(reveal)을 붙이지 않는다.
+        backdrop-filter(.glass-nav) 위에 will-change 레이어가 얹히면 초기 페인트 때
+        inset 하이라이트가 딱딱한 흰 seam으로 렌더되므로, 첫 프레임부터 안정적으로 그린다.
+      {% endcomment %}
       <header style="margin-bottom: var(--space-6); display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:var(--space-2);">
         <nav class="glass-nav" id="ah-topnav">
           <span class="glass-nav__indicator" aria-hidden="true"></span>


### PR DESCRIPTION
## 개요
#183(PR #197)에서 상단 탭 seam 을 고치며 `<header>` 위에 설명 주석을 넣었는데, Django `{# #}` 주석을 **여러 줄**로 작성해 주석이 안 먹히고 화면 상단에 그대로 렌더되고 있었습니다. `{% comment %}...{% endcomment %}` 로 교체합니다.

- 대상: [base.html](products/templates/admin_home/base.html) 상단 탭 바 주석
- PR #197 머지 *이후* 발견된 후속 수정이라 별도 PR 로 올립니다. (현재 main 에 버그 주석이 남아 화면에 노출됨)

Closes #208