### PR TITLE
Refactor(be)/#209 dashboard shell

### DIFF
--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -22,6 +22,185 @@
 }
 
 /* =========================================================
+   0. App Shell — 사이드바 + 토프바 대시보드 레이아웃
+   좌측 고정 사이드바(부분 로딩 후에도 유지되는 persistent shell) +
+   메인(상단 토프바 + 콘텐츠). 좁은 화면에서는 사이드바가
+   오프캔버스 드로어(.is-nav-open)로 전환된다. 색/여백 전부 토큰.
+   ========================================================= */
+.ah-layout {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  min-height: 100vh;
+}
+/* 셸(사이드바) 없는 화면 — 로그인 등. 사이드바 열을 없애 콘텐츠를 풀폭으로 */
+.ah-layout--bare { grid-template-columns: 1fr; }
+
+/* --- 사이드바 --- */
+.ah-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-4) var(--space-3);
+  background: var(--glass-bg-dark);
+  -webkit-backdrop-filter: blur(var(--blur-lg)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--blur-lg)) saturate(var(--glass-saturate));
+  border-right: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-inset-highlight);
+  z-index: 20;
+}
+.ah-sidebar__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2) var(--space-4);
+}
+.ah-sidebar__brand {
+  font-size: var(--fs-title-md);
+  line-height: 1;
+  font-weight: var(--font-weight-extrabold);
+  color: var(--text-on-glass);
+  letter-spacing: 0.02em;
+}
+.ah-sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.ah-sidebar__group {
+  margin: var(--space-3) var(--space-2) var(--space-1);
+  color: var(--glass-highlight);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.ah-sidebar__nav > .ah-sidebar__group:first-child { margin-top: 0; }
+.ah-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-on-glass);
+  font-weight: var(--font-weight-bold);
+  transition: background var(--transition-base), box-shadow var(--transition-base);
+}
+.ah-sidebar__item:hover { background: var(--glass-bg); }
+.ah-sidebar__item.is-active {
+  background: var(--glass-bg-strong);
+  box-shadow: var(--shadow-inset-highlight);
+}
+.ah-sidebar__item.is-active .ah-sidebar__label { color: var(--brand-primary); }
+.ah-sidebar__icon {
+  flex: none;
+  width: var(--space-6);
+  font-size: var(--fs-text-lg);
+  line-height: 1;
+  text-align: center;
+}
+.ah-sidebar__label { font-size: var(--fs-text-sm); }
+.ah-sidebar__foot {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--glass-border);
+}
+.ah-sidebar__logout { width: 100%; }
+
+/* --- 메인(토프바 + 콘텐츠) --- */
+.ah-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* grid 자식 overflow 방지 → 내부 테이블 가로 스크롤이 셸을 밀지 않게 */
+  min-height: 100vh;
+}
+.ah-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: var(--topbar-h);
+  padding: var(--space-2) var(--space-6);
+  background: var(--glass-bg-subtle);
+  -webkit-backdrop-filter: blur(var(--blur-lg)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--blur-lg)) saturate(var(--glass-saturate));
+  border-bottom: 1px solid var(--glass-border);
+}
+.ah-topbar__title { color: var(--text-on-glass); margin: 0; }
+.ah-topbar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.ah-topbar__menu {
+  display: none; /* 데스크톱에서는 숨김, 모바일 미디어쿼리에서 표시 */
+  flex: none;
+  width: calc(40px * var(--ui-scale));
+  height: calc(40px * var(--ui-scale));
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-title-md);
+  color: var(--text-on-glass);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+.ah-content-scroll {
+  flex: 1 1 auto;
+  padding: var(--space-6);
+}
+.ah-content-scroll > #ah-content {
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+}
+
+/* 드로어 스크림(모바일에서 사이드바 열릴 때만) */
+.ah-sidebar__scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 19;
+  background: var(--scrim);
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+  backdrop-filter: blur(var(--blur-sm));
+}
+
+/* --- 반응형: 사이드바 오프캔버스 드로어 --- */
+@media (max-width: 900px) {
+  .ah-layout { grid-template-columns: 1fr; }
+  .ah-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: min(var(--sidebar-width), 82vw);
+    transform: translateX(-100%);
+    transition: transform var(--transition-base);
+  }
+  .ah-layout.is-nav-open .ah-sidebar { transform: translateX(0); }
+  .ah-layout.is-nav-open .ah-sidebar__scrim { display: block; }
+  .ah-topbar__menu { display: inline-flex; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ah-sidebar { transition: none; }
+}
+
+/* backdrop-filter 미지원 폴백 — 셸은 어두운 톤을 유지(불투명 배경) */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ah-sidebar,
+  .ah-topbar {
+    background: var(--glass-bg-dark-fallback);
+    border-color: var(--color-gray-700);
+  }
+}
+
+/* =========================================================
    1. Buttons
    ========================================================= */
 .btn {

--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -64,25 +64,32 @@
   color: var(--text-on-glass);
   letter-spacing: 0.02em;
 }
+/* "ADMIN" — 배지 대신 브랜드 뒤에 이어 쓰는 텍스트(옅은 톤·보통 굵기) */
+.ah-sidebar__brand-sub {
+  margin-left: 0.4em;
+  color: var(--glass-highlight);
+  font-weight: var(--font-weight-regular);
+  letter-spacing: 0.08em;
+}
 .ah-sidebar__nav {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
   flex: 1 1 auto;
   overflow-y: auto;
 }
 .ah-sidebar__group {
-  margin: var(--space-3) var(--space-2) var(--space-1);
+  margin: var(--space-6) var(--space-2) var(--space-2);
   color: var(--glass-highlight);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-.ah-sidebar__nav > .ah-sidebar__group:first-child { margin-top: 0; }
+.ah-sidebar__nav > .ah-sidebar__group:first-child { margin-top: var(--space-1); }
 .ah-sidebar__item {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
+  gap: var(--space-3);
+  padding: var(--space-3);
   border-radius: var(--radius-md);
   color: var(--text-on-glass);
   font-weight: var(--font-weight-bold);

--- a/products/static/admin_home/css/tokens.css
+++ b/products/static/admin_home/css/tokens.css
@@ -183,19 +183,24 @@
      레이아웃 / 배경 (base.html 에서 교체 가능)
      --------------------------------------------------------- */
   --admin-max-width: calc(1200px * var(--ui-scale));
+  /* 대시보드 셸: 사이드바 폭 / 토프바 높이 / 콘텐츠 최대폭 (전역 스케일 연동) */
+  --sidebar-width: calc(244px * var(--ui-scale));
+  --topbar-h: calc(60px * var(--ui-scale));
+  --content-max-width: calc(1360px * var(--ui-scale));
   --transition-base: 200ms ease;
-  /* ref1 톤: 은은한 그린-블루 그라데이션 배경 (이미지로 교체 가능) */
+  /* 대시보드 톤: 데이터 가독성을 위해 배경 글로우를 은은하게 낮춘다(랜딩 → admin).
+     이미지로 교체하려면 --admin-bg-image 만 바꾸면 된다. */
   --admin-bg-image: none;
-  --admin-bg-color: var(--color-gray-900);
+  --admin-bg-color: var(--color-gray-950);
   --admin-bg-gradient: radial-gradient(
-      1200px 800px at 15% 10%,
-      rgba(80, 216, 143, 0.28),
-      transparent 60%
-    ),
-    radial-gradient(
-      1000px 700px at 90% 20%,
-      rgba(83, 152, 255, 0.24),
+      1100px 700px at 12% -5%,
+      rgba(80, 216, 143, 0.12),
       transparent 55%
     ),
-    linear-gradient(160deg, var(--color-gray-800), var(--color-gray-950));
+    radial-gradient(
+      900px 650px at 100% 0%,
+      rgba(83, 152, 255, 0.10),
+      transparent 55%
+    ),
+    linear-gradient(165deg, var(--color-gray-900), var(--color-gray-950));
 }

--- a/products/static/admin_home/js/interactions.js
+++ b/products/static/admin_home/js/interactions.js
@@ -141,10 +141,49 @@
     });
   }
 
+  /* -----------------------------------------------------------
+     사이드바 드로어 — 좁은 화면에서 햄버거(#ah-menu-toggle)로 사이드바를
+     오프캔버스로 열고 닫는다. 사이드바/토프바는 지속 셸이라 한 번만 배선한다
+     (부분 로딩으로 재호출돼도 _ahSidebarWired 가드로 중복 방지).
+     ----------------------------------------------------------- */
+  function initSidebarToggle() {
+    if (document._ahSidebarWired) return;
+    var layout = document.getElementById("ah-layout");
+    var toggle = document.getElementById("ah-menu-toggle");
+    if (!layout || !toggle) return;
+    document._ahSidebarWired = "1";
+
+    var scrim = document.getElementById("ah-sidebar-scrim");
+    function setOpen(open) {
+      layout.classList.toggle("is-nav-open", open);
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    }
+
+    toggle.addEventListener("click", function () {
+      setOpen(!layout.classList.contains("is-nav-open"));
+    });
+    if (scrim) {
+      scrim.addEventListener("click", function () {
+        setOpen(false);
+      });
+    }
+    // 사이드바 메뉴 클릭(모바일) 후에는 드로어를 닫는다.
+    layout.addEventListener("click", function (e) {
+      if (e.target.closest && e.target.closest(".ah-sidebar__item")) {
+        setOpen(false);
+      }
+    });
+    // Esc 로 닫기
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" || e.keyCode === 27) setOpen(false);
+    });
+  }
+
   function init() {
     document.querySelectorAll(".glass-nav").forEach(wireNav);
     initGlassSheen();
     initModals();
+    initSidebarToggle();
   }
 
   // 창 크기 변경 시 모든 nav 인디케이터 위치 재계산 (전역에 한 번만 바인딩)

--- a/products/static/admin_home/js/partial-nav.js
+++ b/products/static/admin_home/js/partial-nav.js
@@ -51,11 +51,11 @@
     });
   }
 
-  // 상단 탭(#ah-topnav)만 활성 상태를 갱신한다.
-  function updateTopNav(path) {
-    var nav = document.getElementById("ah-topnav");
+  // 좌측 사이드바(#ah-sidebar)의 활성 메뉴만 갱신한다(부분 로딩 후에도 유지되는 셸).
+  function updateSidebarActive(path) {
+    var nav = document.getElementById("ah-sidebar");
     if (!nav) return;
-    nav.querySelectorAll(".glass-nav__item").forEach(function (item) {
+    nav.querySelectorAll(".ah-sidebar__item").forEach(function (item) {
       var href = item.getAttribute("href");
       if (!href || href.indexOf(PREFIX.slice(0, -1)) !== 0) {
         // /admin/home 밖(기존 Admin 등)은 활성 대상 아님
@@ -66,6 +66,21 @@
         href === path || (href !== PREFIX && path.indexOf(href) === 0);
       item.classList.toggle("is-active", active);
     });
+  }
+
+  // 토프바(지속 셸)의 페이지 타이틀/액션을 응답 fragment 의 마커로 갱신한다.
+  function updateTopbar(frag) {
+    var titleMarker = frag.querySelector("[data-ah-topbar-title]");
+    var titleEl = document.getElementById("ah-topbar-title");
+    if (titleMarker && titleEl) {
+      titleEl.textContent =
+        titleMarker.getAttribute("data-ah-topbar-title") || "";
+    }
+    var actionsMarker = frag.querySelector("[data-ah-topbar-actions]");
+    var actionsEl = document.getElementById("ah-topbar-actions");
+    if (actionsEl) {
+      actionsEl.innerHTML = actionsMarker ? actionsMarker.innerHTML : "";
+    }
   }
 
   // 중첩 부분 교체 시, 유지되는 서브내비의 활성 탭을 응답(fragment)의 값과 맞춘다.
@@ -113,8 +128,11 @@
       document.title = titleMarker.getAttribute("data-ah-title") || document.title;
     }
 
-    // 상단 탭 활성 갱신 (경로 기준)
-    updateTopNav(url.split("?")[0].split("#")[0]);
+    // 토프바 페이지 타이틀/액션 갱신 (지속 셸)
+    updateTopbar(frag);
+
+    // 사이드바 활성 메뉴 갱신 (경로 기준)
+    updateSidebarActive(url.split("?")[0].split("#")[0]);
 
     // 디자인 시스템 재초기화(reveal 등장, nav 인디케이터/서브내비 배선)
     document.dispatchEvent(new CustomEvent("ah:content-loaded"));

--- a/products/templates/admin_home/_partial_base.html
+++ b/products/templates/admin_home/_partial_base.html
@@ -4,11 +4,14 @@
   X-Partial-Nav 헤더가 붙은 요청일 때 admin_home 뷰가 base 대신 이 템플릿으로 확장한다.
   (base.html 과 동일한 블록 이름을 사용 → 페이지 템플릿은 수정 없이 그대로 재사용된다.)
 
-  포함 순서: 제목 마커 → 페이지 전용 CSS(extra_head) → 콘텐츠 → 페이지 전용 JS(extra_js).
-  partial-nav.js 가 스왑 후 data-ah-title 로 document.title 을 갱신하고,
+  포함 순서: 제목/토프바 마커 → 페이지 전용 CSS(extra_head) → 콘텐츠 → 페이지 전용 JS(extra_js).
+  partial-nav.js 가 스왑 후 data-ah-title 로 document.title 을, data-ah-topbar-title 로
+  토프바 페이지 타이틀을, data-ah-topbar-actions 안의 마크업으로 토프바 액션을 갱신하고,
   삽입된 <script> 를 재실행한다. (<style> 은 innerHTML 삽입만으로 적용됨)
 {% endcomment %}
 <span data-ah-title="{% block title %}Admin Home{% endblock %}" hidden></span>
+<span data-ah-topbar-title="{% block topbar_title %}관리자{% endblock %}" hidden></span>
+<div data-ah-topbar-actions hidden>{% block topbar_actions %}{% endblock %}</div>
 {% block extra_head %}{% endblock %}
 {% block content %}{% endblock %}
 {% block extra_js %}{% endblock %}

--- a/products/templates/admin_home/_styleguide.html
+++ b/products/templates/admin_home/_styleguide.html
@@ -6,6 +6,7 @@
 {% endcomment %}
 
 {% block title %}디자인 시스템 스타일가이드 · /admin/home{% endblock %}
+{% block topbar_title %}스타일가이드{% endblock %}
 
 {% block extra_head %}
 <style>

--- a/products/templates/admin_home/banner_list.html
+++ b/products/templates/admin_home/banner_list.html
@@ -7,6 +7,7 @@
 {% endcomment %}
 
 {% block title %}배너 · DASII{% endblock %}
+{% block topbar_title %}배너 관리{% endblock %}
 
 {% block extra_head %}
 <style>

--- a/products/templates/admin_home/base.html
+++ b/products/templates/admin_home/base.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="{% static 'admin_home/css/vendor-overrides.css' %}" />
 
   <style>
-    /* 배경은 토큰으로 분리 → 페이지/이미지 교체가 쉽도록 */
+    /* 배경은 토큰으로 분리 → 페이지/이미지 교체가 쉽도록. 레이아웃은 components.css(.ah-layout) 담당 */
     html, body { min-height: 100%; }
     body.admin-home {
       background-color: var(--admin-bg-color);
@@ -25,10 +25,6 @@
       background-position: center;
       background-attachment: fixed;
       color: var(--text-on-glass);
-    }
-    .admin-home__main {
-      min-height: 100vh;
-      padding: var(--space-6) 0 var(--space-8);
     }
   </style>
 
@@ -46,34 +42,73 @@
     {% endif %}
   </div>
 
-  <main class="admin-home__main">
-    <div class="ah-container">
-      {# 상단 탭 + 로그아웃 바 — 페이지 전환(부분 로딩) 후에도 항상 유지되는 영역 #}
+  {% comment %}
+    앱 셸 — 좌측 사이드바 + 메인(토프바 + 콘텐츠).
+    사이드바/토프바는 부분 로딩(partial-nav.js) 후에도 유지되는 persistent shell 이며,
+    #ah-content 안의 내용만 교체된다. 활성 메뉴/토프바 타이틀/액션은 partial-nav.js 가 갱신한다.
+  {% endcomment %}
+  <div class="ah-layout {% block layout_mod %}{% endblock %}" id="ah-layout">
+    {% block sidebar %}
+    <aside class="ah-sidebar" id="ah-sidebar">
+      <div class="ah-sidebar__head">
+        <span class="ah-sidebar__brand">DASII</span>
+        <span class="ah-badge ah-badge--neutral">ADMIN</span>
+      </div>
+      <nav class="ah-sidebar__nav" aria-label="관리 메뉴">
+        <p class="ah-sidebar__group text-caption">콘텐츠 관리</p>
+        <a class="ah-sidebar__item {% if request.resolver_match.url_name == 'admin_home' %}is-active{% endif %}" href="{% url 'admin_home' %}">
+          <span class="ah-sidebar__icon" aria-hidden="true">🏠</span>
+          <span class="ah-sidebar__label">홈</span>
+        </a>
+        <a class="ah-sidebar__item {% if 'admin_home_category' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_category' %}">
+          <span class="ah-sidebar__icon" aria-hidden="true">🗂️</span>
+          <span class="ah-sidebar__label">카테고리</span>
+        </a>
+        <a class="ah-sidebar__item {% if request.resolver_match.url_name == 'admin_home_product' %}is-active{% endif %}" href="{% url 'admin_home_product' %}">
+          <span class="ah-sidebar__icon" aria-hidden="true">📦</span>
+          <span class="ah-sidebar__label">제품</span>
+        </a>
+        <a class="ah-sidebar__item {% if 'admin_home_ingredient' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_ingredient' %}">
+          <span class="ah-sidebar__icon" aria-hidden="true">🧪</span>
+          <span class="ah-sidebar__label">원료</span>
+        </a>
+        <a class="ah-sidebar__item {% if 'admin_home_banner' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_banner' %}">
+          <span class="ah-sidebar__icon" aria-hidden="true">🖼️</span>
+          <span class="ah-sidebar__label">배너</span>
+        </a>
+        <p class="ah-sidebar__group text-caption">시스템</p>
+        <a class="ah-sidebar__item" href="{% url 'admin_main' %}" data-no-partial>
+          <span class="ah-sidebar__icon" aria-hidden="true">🛠️</span>
+          <span class="ah-sidebar__label">기존 Admin</span>
+        </a>
+      </nav>
+      <div class="ah-sidebar__foot">
+        <a class="btn btn-glass ah-sidebar__logout" href="{% url 'admin_logout' %}" data-no-partial>로그아웃</a>
+      </div>
+    </aside>
+    <div class="ah-sidebar__scrim" id="ah-sidebar-scrim"></div>
+    {% endblock %}
+
+    <div class="ah-main">
       {% block topbar %}
-      {# 상단 탭 바는 persistent shell — 진입 애니메이션(reveal)을 붙이지 않는다.
-         backdrop-filter(.glass-nav) 위에 will-change 레이어가 얹히면 초기 페인트 때
-         inset 하이라이트가 딱딱한 흰 seam으로 렌더되므로, 첫 프레임부터 안정적으로 그린다. #}
-      <header style="margin-bottom: var(--space-6); display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:var(--space-2);">
-        <nav class="glass-nav" id="ah-topnav">
-          <span class="glass-nav__indicator" aria-hidden="true"></span>
-          <a class="glass-nav__item {% if request.resolver_match.url_name == 'admin_home' %}is-active{% endif %}" href="{% url 'admin_home' %}">Home</a>
-          <a class="glass-nav__item {% if 'admin_home_category' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_category' %}">Category</a>
-          <a class="glass-nav__item {% if request.resolver_match.url_name == 'admin_home_product' %}is-active{% endif %}" href="{% url 'admin_home_product' %}">Product</a>
-          <a class="glass-nav__item {% if 'admin_home_ingredient' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_ingredient' %}">Ingredient</a>
-          <a class="glass-nav__item {% if 'admin_home_banner' in request.resolver_match.url_name|default:'' %}is-active{% endif %}" href="{% url 'admin_home_banner' %}">Banner</a>
-          <a class="glass-nav__item" href="{% url 'admin_main' %}" data-no-partial>기존 Admin</a>
-          {% block topbar_extra %}{% endblock %}
-        </nav>
-        <a class="btn btn-glass" href="{% url 'admin_logout' %}" data-no-partial>로그아웃</a>
+      <header class="ah-topbar">
+        <button type="button" class="ah-topbar__menu" id="ah-menu-toggle"
+                aria-label="메뉴 열기" aria-controls="ah-sidebar" aria-expanded="false">
+          <span aria-hidden="true">☰</span>
+        </button>
+        <h1 class="ah-topbar__title text-title-md" id="ah-topbar-title">{% block topbar_title %}관리자{% endblock %}</h1>
+        <div class="ah-topbar__actions" id="ah-topbar-actions">{% block topbar_actions %}{% endblock %}</div>
       </header>
       {% endblock %}
 
-      {# 부분 로딩 시 이 영역의 내용만 교체된다(상단 탭 바는 그대로 유지) #}
-      <div id="ah-content">
-        {% block content %}{% endblock %}
+      {# 부분 로딩 시 이 영역의 내용만 교체된다(사이드바·토프바는 그대로 유지) #}
+      <div class="ah-content-scroll">
+        <div id="ah-content">
+          {% block content %}{% endblock %}
+        </div>
       </div>
     </div>
-  </main>
+  </div>
 
   {# 디자인 시스템 인터랙션 스크립트 #}
   <script src="{% static 'admin_home/js/reveal.js' %}" defer></script>

--- a/products/templates/admin_home/base.html
+++ b/products/templates/admin_home/base.html
@@ -51,8 +51,7 @@
     {% block sidebar %}
     <aside class="ah-sidebar" id="ah-sidebar">
       <div class="ah-sidebar__head">
-        <span class="ah-sidebar__brand">DASII</span>
-        <span class="ah-badge ah-badge--neutral">ADMIN</span>
+        <span class="ah-sidebar__brand">DASII<span class="ah-sidebar__brand-sub">ADMIN</span></span>
       </div>
       <nav class="ah-sidebar__nav" aria-label="관리 메뉴">
         <p class="ah-sidebar__group text-caption">콘텐츠 관리</p>

--- a/products/templates/admin_home/category_tree.html
+++ b/products/templates/admin_home/category_tree.html
@@ -9,6 +9,7 @@
 {% endcomment %}
 
 {% block title %}카테고리 · DASII{% endblock %}
+{% block topbar_title %}카테고리 관리{% endblock %}
 
 {% block content %}
 <section class="glass-card reveal"

--- a/products/templates/admin_home/home.html
+++ b/products/templates/admin_home/home.html
@@ -5,6 +5,7 @@
 {% endcomment %}
 
 {% block title %}Admin Home · DASII{% endblock %}
+{% block topbar_title %}홈{% endblock %}
 
 {% block extra_head %}
 <style>

--- a/products/templates/admin_home/ingredient_list.html
+++ b/products/templates/admin_home/ingredient_list.html
@@ -11,6 +11,7 @@
 {% endcomment %}
 
 {% block title %}원료 · 기능성 원료 · DASII{% endblock %}
+{% block topbar_title %}원료 관리{% endblock %}
 
 {% block content %}
 {% include "admin_home/components/_ingredient_subnav.html" %}

--- a/products/templates/admin_home/ingredient_other.html
+++ b/products/templates/admin_home/ingredient_other.html
@@ -10,6 +10,7 @@
 {% endcomment %}
 
 {% block title %}원료 · 기타 원료 · DASII{% endblock %}
+{% block topbar_title %}원료 관리{% endblock %}
 
 {% block content %}
 {% include "admin_home/components/_ingredient_subnav.html" %}

--- a/products/templates/admin_home/product_list.html
+++ b/products/templates/admin_home/product_list.html
@@ -9,6 +9,7 @@
 {% endcomment %}
 
 {% block title %}제품 · DASII{% endblock %}
+{% block topbar_title %}제품 관리{% endblock %}
 
 {% block content %}
 

--- a/products/templates/products/admin_login.html
+++ b/products/templates/products/admin_login.html
@@ -8,6 +8,9 @@
 
 {% block title %}관리자 인증 · DASII{% endblock %}
 
+{# 로그인 화면은 앱 셸(사이드바/토프바) 없이 폼만 중앙에 표시한다 #}
+{% block layout_mod %}ah-layout--bare{% endblock %}
+{% block sidebar %}{% endblock %}
 {% block topbar %}{% endblock %}
 
 {% block extra_head %}


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
기존 상단 탭바(glass-nav) 단일 구조를 좌측 사이드바 + 상단 토프바(햄버거 메뉴, 페이지 타이틀, 액션 슬롯) 조합으로 전면 재구성
부분 로딩(partial-nav.js) 시 사이드바 활성 메뉴, 토프바 타이틀/액션을 지속 셸 안에서 갱신하도록 마커(data-ah-topbar-title, data-ah-topbar-actions) 배선
좁은 화면에서 사이드바를 오프캔버스 드로어로 열고 닫는 토글 추가(스크림 클릭/ESC/메뉴 클릭 시 닫힘)
<!-- A clear and concise description about the feature -->

## 이슈

<!-- Add a issues that referenced this pull request -->
