### PR TITLE
Feat(be)/#210 home dashboard

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -13,6 +13,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import Count, Max, Prefetch, ProtectedError
 from django.db.models.functions import TruncDate
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.utils import timezone
 
 from common.models import Banner, BannerDetail
@@ -225,13 +226,56 @@ def _signup_chart(days=30):
     }
 
 
-def home(request):
-    """/admin/home 랜딩(홈). 로그인 후 진입 지점.
+def _home_kpis(chart):
+    """홈 대시보드 상단 KPI 스탯 타일용 집계(읽기 전용 count).
 
-    홈 카드 중 "제품 추가 요청"은 사용자가 보낸 ProductRequest 목록을
-    모달로 보여준다(기존 admin product_request_list 기능 이식).
-    action=delete 로 개별 요청을 삭제할 수 있다.
-    하단에는 최근 30일 가입 추이 미니 차트(신규+누적)를 표시한다.
+    카탈로그/회원 규모를 한눈에 보여준다. 각 타일은 label/value/icon 과
+    선택적으로 관리 페이지로 가는 href 를 갖는다(_stat.html 컴포넌트가 렌더).
+    오늘 신규 가입은 이미 계산된 signup_chart(chart) 값을 재사용한다.
+    """
+    return [
+        {"label": "총 회원", "value": User.objects.count(), "icon": "👥"},
+        {"label": "오늘 신규 가입", "value": chart["today_new"], "icon": "🌱"},
+        {
+            "label": "제품",
+            "value": Product.objects.count(),
+            "icon": "📦",
+            "href": reverse("admin_home_product"),
+        },
+        {
+            "label": "기능성 원료",
+            "value": Ingredient.objects.count(),
+            "icon": "🧪",
+            "href": reverse("admin_home_ingredient"),
+        },
+        {
+            "label": "기타 원료",
+            "value": OtherIngredient.objects.count(),
+            "icon": "🧴",
+            "href": reverse("admin_home_ingredient_other"),
+        },
+        {
+            "label": "소분류",
+            "value": SmallCategory.objects.count(),
+            "icon": "🗂️",
+            "href": reverse("admin_home_category"),
+        },
+        {
+            "label": "배너",
+            "value": Banner.objects.count(),
+            "icon": "🖼️",
+            "href": reverse("admin_home_banner"),
+        },
+    ]
+
+
+def home(request):
+    """/admin/home 랜딩(홈). 로그인 후 진입 지점 — 대시보드 개요.
+
+    상단에 카탈로그/회원 규모 KPI 스탯 타일을 두고, 그 아래 최근 30일 가입 추이
+    미니 차트(신규 막대 + 누적 스파크라인)와 "제품 추가 요청" 위젯을 배치한다.
+    제품 추가 요청은 사용자가 보낸 ProductRequest 목록으로, 위젯의 "전체 보기"가
+    여는 모달에서 확인/삭제한다(action=delete). 모든 집계는 읽기 전용이다.
     """
     if request.method == "POST" and request.POST.get("action") == "delete":
         try:
@@ -244,12 +288,14 @@ def home(request):
     product_requests = ProductRequest.objects.select_related("user").order_by(
         "-created_at"
     )
+    chart = _signup_chart(30)
     return _ah_render(
         request,
         "admin_home/home.html",
         {
             "product_requests": product_requests,
-            "signup_chart": _signup_chart(30),
+            "signup_chart": chart,
+            "kpis": _home_kpis(chart),
         },
     )
 

--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -20,6 +20,8 @@
   gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
+/* 스탯 타일 행 — 카드보다 촘촘하게(한 줄에 여러 KPI) */
+.ah-grid--stats { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
 
 /* =========================================================
    0. App Shell — 사이드바 + 토프바 대시보드 레이아웃
@@ -324,6 +326,67 @@
     border-color: var(--color-gray-200);
   }
   .glass-card__desc { color: var(--text-muted); }
+}
+
+/* =========================================================
+   2-1. Stat Tile — 대시보드 KPI 타일(_stat.html)
+   아이콘 + (라벨/값/보조). href 있으면 링크 타일(.ah-stat--link).
+   ========================================================= */
+.ah-stat {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--glass-bg);
+  -webkit-backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-glass), var(--shadow-inset-highlight);
+  color: var(--text-on-glass);
+}
+.ah-stat__icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-8);
+  height: var(--space-8);
+  font-size: var(--fs-title-md);
+  line-height: 1;
+  background: var(--glass-bg-strong);
+  border-radius: var(--radius-md);
+}
+.ah-stat__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.ah-stat__label { color: var(--glass-highlight); }
+.ah-stat__value { font-weight: var(--font-weight-extrabold); line-height: 1.1; }
+.ah-stat__unit {
+  margin-left: 2px;
+  color: var(--glass-highlight);
+  font-weight: var(--font-weight-regular);
+}
+.ah-stat__sub { color: var(--glass-highlight); }
+.ah-stat--link {
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base), border-color var(--transition-base);
+}
+.ah-stat--link:hover { border-color: var(--glass-border-strong); }
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ah-stat {
+    background: var(--glass-bg-fallback);
+    color: var(--text-default);
+    border-color: var(--color-gray-200);
+  }
+  .ah-stat__label,
+  .ah-stat__sub,
+  .ah-stat__unit { color: var(--text-muted); }
+  .ah-stat__icon { background: var(--surface-subtle); }
 }
 
 /* =========================================================

--- a/products/templates/admin_home/components/_stat.html
+++ b/products/templates/admin_home/components/_stat.html
@@ -1,0 +1,15 @@
+{% comment %}
+  스탯 타일 — 대시보드 KPI 한 칸.
+  사용: {% include "admin_home/components/_stat.html" with label="총 회원" value=123 icon="👥" href="..." %}
+  - label (필수), value (필수)
+  - icon (선택, 이모지/문자), unit (선택, 값 뒤 단위), sub (선택, 보조 설명)
+  - href (선택): 있으면 클릭 가능한 링크 타일(<a>), 없으면 정적 타일(<div>)
+{% endcomment %}
+{% if href %}<a class="ah-stat ah-stat--link lift" href="{{ href }}">{% else %}<div class="ah-stat">{% endif %}
+  {% if icon %}<span class="ah-stat__icon" aria-hidden="true">{{ icon }}</span>{% endif %}
+  <span class="ah-stat__body">
+    <span class="ah-stat__label text-caption">{{ label }}</span>
+    <span class="ah-stat__value text-title-lg">{{ value }}{% if unit %}<span class="ah-stat__unit text-body-sm">{{ unit }}</span>{% endif %}</span>
+    {% if sub %}<span class="ah-stat__sub text-caption">{{ sub }}</span>{% endif %}
+  </span>
+{% if href %}</a>{% else %}</div>{% endif %}

--- a/products/templates/admin_home/home.html
+++ b/products/templates/admin_home/home.html
@@ -1,6 +1,7 @@
 {% extends base_template|default:"admin_home/base.html" %}
 {% comment %}
-  /admin/home 랜딩(홈). 로그인 후 진입 지점.
+  /admin/home 랜딩(홈) — 대시보드 개요.
+  상단 KPI 스탯 타일 행 + 가입 추이 패널 + 제품 추가 요청 위젯(모달).
   신규 관리자 기능은 이 아래(/admin/home/<name>/)에 추가된다.
 {% endcomment %}
 
@@ -9,24 +10,17 @@
 
 {% block extra_head %}
 <style>
-  /* 가입 추이 미니 차트 — 토큰만 사용, 외부 라이브러리 없음 */
-  .sc-stats {
-    display: flex;
-    flex-wrap: wrap;
+  /* 대시보드 2단 그리드 + 가입 추이 미니 차트 — 토큰만 사용, 외부 라이브러리 없음 */
+  .ah-dashboard-grid {
+    display: grid;
     gap: var(--space-3);
-    margin-bottom: var(--space-6);
+    grid-template-columns: 2fr 1fr;
+    align-items: start;
   }
-  .sc-stat {
-    flex: 1 1 160px;
-    padding: var(--space-4);
-    border-radius: var(--radius-md);
-    background: var(--glass-bg);
-    border: 1px solid var(--glass-border);
+  @media (max-width: 900px) {
+    .ah-dashboard-grid { grid-template-columns: 1fr; }
   }
-  .sc-stat__label { color: var(--glass-highlight); }
-  .sc-stat__value { margin-top: var(--space-1); }
 
-  .sc-chart { margin-top: var(--space-4); }
   .sc-chart__head {
     display: flex;
     align-items: baseline;
@@ -61,11 +55,7 @@
 
   /* 누적 총합 스파크라인 */
   .sc-spark { margin-top: var(--space-6); }
-  .sc-spark__svg {
-    display: block;
-    width: 100%;
-    height: 64px;
-  }
+  .sc-spark__svg { display: block; width: 100%; height: 64px; }
   .sc-spark__area { fill: var(--color-green-500); opacity: 0.14; }
   .sc-spark__line {
     fill: none;
@@ -74,56 +64,51 @@
     stroke-linejoin: round;
     stroke-linecap: round;
   }
-
   .sc-axis {
     display: flex;
     justify-content: space-between;
     margin-top: var(--space-2);
     color: var(--glass-highlight);
   }
+
+  /* 제품 추가 요청 위젯의 최근 항목 미리보기 */
+  .pr-preview { display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-3); }
+  .pr-preview__item {
+    padding: var(--space-2) var(--space-3);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+  }
+  .pr-preview__content {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .pr-preview__date { color: var(--glass-highlight); }
 </style>
 {% endblock %}
 
 {% block content %}
-<section class="ah-grid" data-reveal-stagger>
-  {# Style Guide 카드 → 제품 추가 요청 카드로 교체. 클릭 시 목록 모달을 연다. #}
-  <button type="button" class="glass-card reveal" data-modal-open="pr-modal"
-          style="text-align:left; cursor:pointer; font-family:inherit; width:100%;">
-    <h3 class="glass-card__title">제품 추가 요청</h3>
-    <p class="glass-card__desc">사용자가 보낸 제품 추가 요청을 확인합니다. ({{ product_requests|length }}건)</p>
-    <div class="glass-card__icon" aria-hidden="true">📨</div>
-  </button>
-  {% include "admin_home/components/_card.html" with title="곧 추가됩니다" desc="신규 관리 기능이 여기에 배치됩니다." icon="✨" %}
+{# 상단 KPI 스탯 타일 행 #}
+<section class="ah-grid ah-grid--stats" data-reveal-stagger style="margin-bottom: var(--space-6);">
+  {% for s in kpis %}
+  <div class="reveal">
+    {% include "admin_home/components/_stat.html" with label=s.label value=s.value icon=s.icon href=s.href sub=s.sub %}
+  </div>
+  {% endfor %}
 </section>
 
-{# 가입 추이 미니 차트 — 최근 30일 신규 가입(막대) + 누적 총 회원(스파크라인) #}
-<section class="glass-panel reveal" style="margin-top: var(--space-6);">
-  <div class="sc-chart__head">
-    <h2 class="text-title-md">가입 추이</h2>
-    <span class="text-body-sm" style="color: var(--glass-highlight);">
-      최근 {{ signup_chart.days }}일 · KST 기준
-    </span>
-  </div>
-
-  <div class="sc-stats">
-    <div class="sc-stat">
-      <p class="sc-stat__label text-body-sm">최근 {{ signup_chart.days }}일 신규</p>
-      <p class="sc-stat__value text-title-lg">{{ signup_chart.new_total }}<span class="text-body-sm">명</span></p>
-    </div>
-    <div class="sc-stat">
-      <p class="sc-stat__label text-body-sm">오늘 신규</p>
-      <p class="sc-stat__value text-title-lg">{{ signup_chart.today_new }}<span class="text-body-sm">명</span></p>
-    </div>
-    <div class="sc-stat">
-      <p class="sc-stat__label text-body-sm">누적 총 회원</p>
-      <p class="sc-stat__value text-title-lg">{{ signup_chart.grand_total }}<span class="text-body-sm">명</span></p>
-    </div>
-  </div>
-
-  <div class="sc-chart">
+<div class="ah-dashboard-grid">
+  {# 가입 추이 — 최근 30일 신규 가입(막대) + 누적 총 회원(스파크라인) #}
+  <section class="glass-panel reveal">
     <div class="sc-chart__head">
-      <span class="text-body-sm">일자별 신규 가입</span>
+      <h2 class="text-title-md">가입 추이</h2>
+      <span class="text-body-sm" style="color: var(--glass-highlight);">
+        최근 {{ signup_chart.days }}일 · KST · 신규 {{ signup_chart.new_total }}명 / 누적 {{ signup_chart.grand_total }}명
+      </span>
     </div>
+
     <div class="sc-bars" role="img"
          aria-label="최근 {{ signup_chart.days }}일 일자별 신규 가입 수 막대 그래프">
       {% for p in signup_chart.points %}
@@ -137,25 +122,50 @@
       <span class="text-caption">{{ signup_chart.start_date|date:'n/j' }}</span>
       <span class="text-caption">{{ signup_chart.end_date|date:'n/j' }}</span>
     </div>
-  </div>
 
-  <div class="sc-spark">
-    <div class="sc-chart__head">
-      <span class="text-body-sm">누적 총 회원</span>
+    <div class="sc-spark">
+      <div class="sc-chart__head">
+        <span class="text-body-sm">누적 총 회원</span>
+      </div>
+      <svg class="sc-spark__svg" viewBox="0 0 {{ signup_chart.spark_w }} {{ signup_chart.spark_h }}"
+           preserveAspectRatio="none" role="img"
+           aria-label="최근 {{ signup_chart.days }}일 누적 총 회원 수 추이">
+        {% if signup_chart.spark_area %}
+        <polygon class="sc-spark__area" points="{{ signup_chart.spark_area }}"></polygon>
+        {% endif %}
+        <polyline class="sc-spark__line" vector-effect="non-scaling-stroke"
+                  points="{{ signup_chart.spark_points }}"></polyline>
+      </svg>
     </div>
-    <svg class="sc-spark__svg" viewBox="0 0 {{ signup_chart.spark_w }} {{ signup_chart.spark_h }}"
-         preserveAspectRatio="none" role="img"
-         aria-label="최근 {{ signup_chart.days }}일 누적 총 회원 수 추이">
-      {% if signup_chart.spark_area %}
-      <polygon class="sc-spark__area" points="{{ signup_chart.spark_area }}"></polygon>
-      {% endif %}
-      <polyline class="sc-spark__line" vector-effect="non-scaling-stroke"
-                points="{{ signup_chart.spark_points }}"></polyline>
-    </svg>
-  </div>
-</section>
+  </section>
 
-{# 제품 추가 요청 목록 모달 — 카드 클릭 시 열림(interactions.js) #}
+  {# 제품 추가 요청 위젯 — 최근 몇 건 미리보기 + 전체 보기(모달) #}
+  <section class="glass-panel reveal">
+    <div class="sc-chart__head">
+      <h2 class="text-title-md">제품 추가 요청</h2>
+      <span class="ah-badge ah-badge--neutral">{{ product_requests|length }}건</span>
+    </div>
+    <p class="text-body-sm" style="color: var(--glass-highlight);">사용자가 보낸 제품 추가 요청입니다.</p>
+
+    <div class="pr-preview">
+      {% for req in product_requests|slice:":3" %}
+      <div class="pr-preview__item">
+        <p class="pr-preview__content text-body-sm">{{ req.content }}</p>
+        <span class="pr-preview__date text-caption">{{ req.created_at|date:"Y-m-d H:i" }}</span>
+      </div>
+      {% empty %}
+      <p class="text-body-sm" style="color: var(--glass-highlight);">아직 제품 추가 요청이 없습니다.</p>
+      {% endfor %}
+    </div>
+
+    <button type="button" class="btn btn-glass" data-modal-open="pr-modal"
+            style="margin-top: var(--space-3); width: 100%;">
+      전체 보기 ({{ product_requests|length }})
+    </button>
+  </section>
+</div>
+
+{# 제품 추가 요청 목록 모달 — 위젯의 "전체 보기" 클릭 시 열림(interactions.js) #}
 <div class="ah-modal" id="pr-modal" aria-hidden="true">
   <div class="ah-modal__overlay" data-modal-close></div>
   <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
홈 랜딩에 회원/제품/원료/소분류/배너 카운트 KPI 스탯 타일 7개 추가(_home_kpis())
재사용 가능한 _stat.html 컴포넌트 추가(href 유무로 링크/정적 타일 분기)
레이아웃을 2단 그리드(가입추이 차트 + 제품 추가 요청 위젯)로 재구성
<!-- A clear and concise description about the feature -->

## 이슈

<!-- Add a issues that referenced this pull request -->
