### PR TITLE
refactor(be): 목록 페이지 추가 액션을 토프바 액션 슬롯으로 이관(#211)

### DIFF
--- a/products/templates/admin_home/banner_list.html
+++ b/products/templates/admin_home/banner_list.html
@@ -8,6 +8,9 @@
 
 {% block title %}배너 · DASII{% endblock %}
 {% block topbar_title %}배너 관리{% endblock %}
+{% block topbar_actions %}
+<button type="button" class="btn btn-primary" data-modal-open="banner-create-modal">＋ 배너 추가</button>
+{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -158,12 +161,10 @@
 </div>
 
 <section class="reveal">
-  <div style="display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3);">
+  <div style="margin-bottom: var(--space-3);">
     <h2 class="text-title-sm">
       배너 목록 <span class="text-muted">({{ banners|length }})</span>
     </h2>
-    <button type="button" class="btn btn-primary" data-modal-open="banner-create-modal"
-            title="배너 추가" aria-label="배너 추가">＋</button>
   </div>
 
   {% if banners %}

--- a/products/templates/admin_home/category_tree.html
+++ b/products/templates/admin_home/category_tree.html
@@ -10,20 +10,18 @@
 
 {% block title %}카테고리 · DASII{% endblock %}
 {% block topbar_title %}카테고리 관리{% endblock %}
+{% block topbar_actions %}
+<button type="button" class="btn btn-primary"
+        data-modal-open="category-modal"
+        data-cat-act="create" data-cat-level="big" data-cat-title="대분류 추가">＋ 대분류 추가</button>
+{% endblock %}
 
 {% block content %}
-<section class="glass-card reveal"
-         style="margin-bottom: var(--space-6); display:flex; align-items:center; justify-content:space-between; gap: var(--space-4); flex-wrap:wrap;">
-  <div>
-    <h1 class="text-title-lg">카테고리</h1>
-    <p class="text-body-sm" style="margin-top: var(--space-1);">
-      대·중·소분류를 한 트리에서 관리합니다. 노드에 마우스를 올리면 추가·수정·삭제 버튼이 나타납니다.
-    </p>
-  </div>
-  <button type="button" class="btn btn-primary"
-          data-modal-open="category-modal"
-          data-cat-act="create" data-cat-level="big" data-cat-title="대분류 추가"
-          title="대분류 추가" aria-label="대분류 추가">＋</button>
+<section class="glass-card reveal" style="margin-bottom: var(--space-6);">
+  <p class="text-body-sm">
+    대·중·소분류를 한 트리에서 관리합니다. 노드에 마우스를 올리면 추가·수정·삭제 버튼이 나타나며,
+    새 대분류는 우측 상단 <strong>＋ 대분류 추가</strong> 로 만듭니다.
+  </p>
 </section>
 
 <section class="reveal">
@@ -101,7 +99,7 @@
     {% endfor %}
   </div>
   {% else %}
-  <p class="ah-record-empty text-body">등록된 대분류가 없습니다. 위 ＋ 로 시작하세요.</p>
+  <p class="ah-record-empty text-body">등록된 대분류가 없습니다. 우측 상단 ＋ 대분류 추가 로 시작하세요.</p>
   {% endif %}
 </section>
 

--- a/products/templates/admin_home/ingredient_list.html
+++ b/products/templates/admin_home/ingredient_list.html
@@ -12,6 +12,9 @@
 
 {% block title %}원료 · 기능성 원료 · DASII{% endblock %}
 {% block topbar_title %}원료 관리{% endblock %}
+{% block topbar_actions %}
+<button type="button" class="btn btn-primary" data-modal-open="ing-create-modal">＋ 기능성 원료 추가</button>
+{% endblock %}
 
 {% block content %}
 {% include "admin_home/components/_ingredient_subnav.html" %}
@@ -216,12 +219,10 @@
 
   {# ── 목록 ── #}
   <section class="reveal">
-    <div style="display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3);">
+    <div style="margin-bottom: var(--space-3);">
       <h2 class="text-title-sm">
         기능성 원료 목록 <span class="text-muted">({{ ingredients|length }})</span>
       </h2>
-      <button type="button" class="btn btn-primary" data-modal-open="ing-create-modal"
-              title="기능성 원료 추가" aria-label="기능성 원료 추가">＋</button>
     </div>
 
     {% if ingredients %}
@@ -250,7 +251,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="ah-record-empty text-body">등록된 기능성 원료가 없습니다. 위 ＋ 로 첫 성분을 추가해보세요.</p>
+    <p class="ah-record-empty text-body">등록된 기능성 원료가 없습니다. 우측 상단 ＋ 기능성 원료 추가 로 첫 성분을 추가해보세요.</p>
     {% endif %}
   </section>
 </div>

--- a/products/templates/admin_home/ingredient_other.html
+++ b/products/templates/admin_home/ingredient_other.html
@@ -11,6 +11,9 @@
 
 {% block title %}원료 · 기타 원료 · DASII{% endblock %}
 {% block topbar_title %}원료 관리{% endblock %}
+{% block topbar_actions %}
+<button type="button" class="btn btn-primary" data-modal-open="oi-create-modal">＋ 기타 원료 추가</button>
+{% endblock %}
 
 {% block content %}
 {% include "admin_home/components/_ingredient_subnav.html" %}
@@ -93,12 +96,10 @@
 
   {# ── 목록 ── #}
   <section class="reveal">
-    <div style="display:flex; align-items:center; justify-content:space-between; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3);">
+    <div style="margin-bottom: var(--space-3);">
       <h2 class="text-title-sm">
         기타 원료 목록 <span class="text-muted">({{ others|length }})</span>
       </h2>
-      <button type="button" class="btn btn-primary" data-modal-open="oi-create-modal"
-              title="기타 원료 추가" aria-label="기타 원료 추가">＋</button>
     </div>
 
     {% if others %}
@@ -117,7 +118,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="ah-record-empty text-body">등록된 기타 원료가 없습니다. 위 ＋ 로 첫 기타 원료를 추가해보세요.</p>
+    <p class="ah-record-empty text-body">등록된 기타 원료가 없습니다. 우측 상단 ＋ 기타 원료 추가 로 첫 기타 원료를 추가해보세요.</p>
     {% endif %}
   </section>
 </div>

--- a/products/templates/admin_home/product_list.html
+++ b/products/templates/admin_home/product_list.html
@@ -10,6 +10,9 @@
 
 {% block title %}제품 · DASII{% endblock %}
 {% block topbar_title %}제품 관리{% endblock %}
+{% block topbar_actions %}
+<button type="button" class="btn btn-primary" data-modal-open="product-create-modal">＋ 제품 추가</button>
+{% endblock %}
 
 {% block content %}
 
@@ -131,18 +134,14 @@
     <h2 class="text-title-sm">
       제품 목록 <span class="text-muted">({{ products|length }})</span>
     </h2>
-    <div style="display:flex; align-items:center; gap: var(--space-2); flex-wrap: wrap;">
-      <input
-        class="ah-input"
-        type="search"
-        id="product-search"
-        placeholder="이름 또는 브랜드로 검색"
-        style="max-width: 32ch;"
-        aria-label="제품 검색"
-      />
-      <button type="button" class="btn btn-primary" data-modal-open="product-create-modal"
-              title="제품 추가" aria-label="제품 추가">＋</button>
-    </div>
+    <input
+      class="ah-input"
+      type="search"
+      id="product-search"
+      placeholder="이름 또는 브랜드로 검색"
+      style="max-width: 32ch;"
+      aria-label="제품 검색"
+    />
   </div>
 
   {% if products %}


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
제품/카테고리/원료/기타원료/배너 5개 목록 페이지의 "＋추가" 버튼을 각 페이지 로컬 헤더에서 #209가 만든 지속 토프바 액션 슬롯으로 이동
data-modal-open 타깃은 그대로 유지되어 모달 연결에는 변화 없음
<!-- A clear and concise description about the feature -->

## 이슈
close #211 
<!-- Add a issues that referenced this pull request -->
