### PR TITLE
refactor(be): 카테고리 트리 소분류 세로 나열·대/중/소 동일 비율·설명 섹션 제거(#213)

### DIFF
--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -775,8 +775,10 @@ body.ah-modal-open { overflow: hidden; }
 
 /* =========================================================
    Category Map — 대/중/소 3열 마인드맵
-   1col 대분류 · 2col 중분류 · 3col 소분류. 열 간 커넥터는 border-left 세로선.
-   대분류는 자기 중분류 묶음에 세로 중앙 정렬. 색/여백 전부 토큰, 18px floor 준수.
+   1col 대분류 · 2col 중분류 · 3col 소분류(세로 나열). 열 간 커넥터는 border-left 세로선.
+   세 열은 동일 비율(각 1/3): group 1fr:2fr → branch 1fr:1fr 중첩으로 대=중=소 폭이 같다.
+   소분류는 열 안에서 세로로 나열되며, 상단 정렬(align-items:start)로 시작을 맞춘다.
+   색/여백 전부 토큰, 18px floor 준수.
    ========================================================= */
 .ah-map {
   display: flex;
@@ -785,8 +787,8 @@ body.ah-modal-open { overflow: hidden; }
 }
 .ah-map__group {
   display: grid;
-  grid-template-columns: minmax(150px, 220px) 1fr;
-  align-items: center;
+  grid-template-columns: 1fr 2fr; /* 대 1/3 · (중+소) 2/3 */
+  align-items: start;
   gap: var(--space-4);
 }
 .ah-map__branches {
@@ -798,14 +800,13 @@ body.ah-modal-open { overflow: hidden; }
 }
 .ah-map__branch {
   display: grid;
-  grid-template-columns: minmax(140px, 200px) 1fr;
-  align-items: center;
+  grid-template-columns: 1fr 1fr; /* 중 1/3 · 소 1/3 (group 의 2/3 을 반씩) */
+  align-items: start;
   gap: var(--space-3);
 }
 .ah-map__smalls {
   display: flex;
-  flex-wrap: wrap;
-  align-content: center;
+  flex-direction: column; /* 소분류 세로 나열 */
   gap: var(--space-2);
   border-left: 2px solid var(--glass-border); /* 중 → 소 커넥터 */
   padding-left: var(--space-3);

--- a/products/templates/admin_home/category_tree.html
+++ b/products/templates/admin_home/category_tree.html
@@ -17,16 +17,9 @@
 {% endblock %}
 
 {% block content %}
-<section class="glass-card reveal" style="margin-bottom: var(--space-6);">
-  <p class="text-body-sm">
-    대·중·소분류를 한 트리에서 관리합니다. 노드에 마우스를 올리면 추가·수정·삭제 버튼이 나타나며,
-    새 대분류는 우측 상단 <strong>＋ 대분류 추가</strong> 로 만듭니다.
-  </p>
-</section>
-
 <section class="reveal">
   {% if bigs %}
-  {# 3열 마인드맵 — 1col 대분류 · 2col 중분류 · 3col 소분류, 열 간 커넥터로 연결 #}
+  {# 3열 마인드맵 — 1col 대분류 · 2col 중분류 · 3col 소분류(세로 나열), 열은 동일 비율 #}
   <div class="ah-map">
     {% for big in bigs %}
     <div class="ah-map__group">


### PR DESCRIPTION
- 소분류를 가로 wrap 대신 세로 나열(.ah-map__smalls flex-direction:column)
- 대/중/소 열을 동일 비율로(group 1fr:2fr → branch 1fr:1fr = 각 1/3), 상단 정렬
- 트리 상단 안내 설명 섹션 제거

<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
카테고리 마인드맵 3열(대/중/소)을 동일 비율로 맞춤(1fr:2fr → 1fr:1fr 중첩 그리드)
소분류 항목을 가로 나열에서 세로 나열로 변경
상단 안내 문구 섹션 제거(순수 CSS/템플릿 변경, JS·백엔드 변경 없음)
<!-- A clear and concise description about the feature -->

## 이슈
close #213 
<!-- Add a issues that referenced this pull request -->
