### PR TITLE
feat: 홈 제품 추가 요청 삭제 UX 개선 — 확인 모달·AJAX·토스트·스크롤바(#225)

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Max, Prefetch, ProtectedError
 from django.db.models.functions import TruncDate
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -278,10 +279,20 @@ def home(request):
     여는 모달에서 확인/삭제한다(action=delete). 모든 집계는 읽기 전용이다.
     """
     if request.method == "POST" and request.POST.get("action") == "delete":
+        # AJAX(모달 내 삭제)면 JSON 으로 응답해 모달·리스트를 유지한 채 처리한다.
+        # 일반 폼 제출이면 기존대로 메시지 + 리다이렉트로 폴백한다.
+        is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
         try:
             ProductRequest.objects.get(id=request.POST.get("id", "")).delete()
+            if is_ajax:
+                return JsonResponse({"ok": True})
             messages.success(request, "제품 추가 요청이 삭제되었습니다.")
         except (ProductRequest.DoesNotExist, ValueError):
+            if is_ajax:
+                return JsonResponse(
+                    {"ok": False, "error": "제품 추가 요청을 찾을 수 없습니다."},
+                    status=404,
+                )
             messages.error(request, "제품 추가 요청을 찾을 수 없습니다.")
         return redirect("admin_home")
 

--- a/products/static/admin_home/js/toast.js
+++ b/products/static/admin_home/js/toast.js
@@ -38,12 +38,44 @@
     }, AUTO_DISMISS_MS);
   }
 
+  function getContainer() {
+    var container = document.querySelector(".ah-toast-container");
+    if (!container) {
+      container = document.createElement("div");
+      container.className = "ah-toast-container";
+      container.setAttribute("aria-live", "polite");
+      container.setAttribute("aria-atomic", "true");
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  // 프로그램적으로 토스트를 띄운다(AJAX 후 등). tag: success/error/warning/info.
+  // base.html 이 렌더한 Django messages 토스트와 동일한 마크업/동작을 재사용한다.
+  function showToast(message, tag) {
+    var container = getContainer();
+    var toast = document.createElement("div");
+    toast.className = "ah-toast";
+    toast.setAttribute("data-toast-tag", tag || "info");
+    toast.setAttribute("role", "status");
+    var span = document.createElement("span");
+    span.className = "ah-toast__msg";
+    span.textContent = message == null ? "" : String(message);
+    toast.appendChild(span);
+    container.appendChild(toast);
+    initToast(toast);
+    return toast;
+  }
+
   function init() {
     var container = document.querySelector(".ah-toast-container");
     if (!container) return;
 
     container.querySelectorAll(".ah-toast").forEach(initToast);
   }
+
+  // 다른 스크립트(페이지 extra_js)에서 호출할 수 있도록 전역으로 노출한다.
+  window.ahToast = showToast;
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);

--- a/products/templates/admin_home/home.html
+++ b/products/templates/admin_home/home.html
@@ -71,6 +71,22 @@
     color: var(--glass-highlight);
   }
 
+  /* 스크롤 영역 — 디자인 시스템 톤의 얇은 유리 스크롤바 (요청 리스트 모달 등) */
+  .ah-scroll { scrollbar-width: thin; scrollbar-color: var(--glass-border-strong) transparent; }
+  .ah-scroll::-webkit-scrollbar { width: 10px; }
+  .ah-scroll::-webkit-scrollbar-track { background: transparent; }
+  .ah-scroll::-webkit-scrollbar-thumb {
+    background: var(--glass-border-strong);
+    border-radius: var(--radius-pill);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+  .ah-scroll::-webkit-scrollbar-thumb:hover {
+    background: var(--glass-highlight);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
   /* 제품 추가 요청 위젯의 최근 항목 미리보기 */
   .pr-preview { display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-3); }
   .pr-preview__item {
@@ -143,7 +159,7 @@
   <section class="glass-panel reveal">
     <div class="sc-chart__head">
       <h2 class="text-title-md">제품 추가 요청</h2>
-      <span class="ah-badge ah-badge--neutral">{{ product_requests|length }}건</span>
+      <span class="ah-badge ah-badge--neutral" id="pr-count">{{ product_requests|length }}건</span>
     </div>
     <p class="text-body-sm" style="color: var(--glass-highlight);">사용자가 보낸 제품 추가 요청입니다.</p>
 
@@ -158,7 +174,7 @@
       {% endfor %}
     </div>
 
-    <button type="button" class="btn btn-glass" data-modal-open="pr-modal"
+    <button type="button" class="btn btn-glass" data-modal-open="pr-modal" id="pr-viewall"
             style="margin-top: var(--space-3); width: 100%;">
       전체 보기 ({{ product_requests|length }})
     </button>
@@ -174,9 +190,11 @@
       <h2 id="pr-modal-title" class="text-title-md">제품 추가 요청</h2>
       <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
     </div>
-    <div class="ah-modal__body">
+    <div class="ah-modal__body ah-scroll" id="pr-modal-body">
+      {# AJAX 삭제용 CSRF 토큰 (모달 안에서 한 번만) #}
+      <input type="hidden" id="pr-csrf" value="{{ csrf_token }}" />
       {% for req in product_requests %}
-      <article class="ah-request">
+      <article class="ah-request" id="pr-item-{{ req.id }}">
         <div class="ah-request__top">
           <span class="ah-request__id text-body-sm">요청 #{{ req.id }}</span>
           <span class="ah-request__user text-body-sm">
@@ -186,19 +204,125 @@
         <p class="ah-request__content text-body-sm">{{ req.content }}</p>
         <div class="ah-request__foot">
           <span class="ah-request__date text-caption">요청일: {{ req.created_at|date:"Y-m-d H:i" }}</span>
-          <form method="POST" action="{% url 'admin_home' %}"
-                onsubmit="return confirm('이 제품 추가 요청을 삭제하시겠습니까?');">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="delete" />
-            <input type="hidden" name="id" value="{{ req.id }}" />
-            <button type="submit" class="btn btn-danger">삭제</button>
-          </form>
+          {# 삭제 → 확인 모달 → AJAX 삭제(리스트 유지 + 토스트). extra_js 가 처리 #}
+          <button type="button" class="btn btn-danger" data-pr-delete="{{ req.id }}">삭제</button>
         </div>
       </article>
-      {% empty %}
-      <p class="text-body-sm">아직 제품 추가 요청이 없습니다.</p>
       {% endfor %}
+      <p class="text-body-sm" id="pr-empty" {% if product_requests %}hidden{% endif %}>아직 제품 추가 요청이 없습니다.</p>
     </div>
   </div>
 </div>
+
+{# 삭제 확인 모달 — 요청 삭제 버튼 클릭 시 열리고, "삭제"가 AJAX 로 실제 삭제한다 #}
+<div class="ah-modal" id="pr-delete-modal" aria-hidden="true">
+  <div class="ah-modal__overlay" data-modal-close></div>
+  <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+       aria-labelledby="pr-delete-modal-title" style="width: min(420px, 100%);">
+    <div class="ah-modal__head">
+      <h2 id="pr-delete-modal-title" class="text-title-md">요청 삭제</h2>
+      <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
+    </div>
+    <div class="ah-modal__body">
+      <p class="text-body">이 제품 추가 요청을 삭제하시겠습니까?</p>
+      <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-3);">
+        <button type="button" class="btn btn-glass" data-modal-close>취소</button>
+        <button type="button" class="btn btn-danger" id="pr-delete-confirm">삭제</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  // 제품 추가 요청 삭제 — 확인 모달 → AJAX 삭제 → 리스트 유지 + 토스트.
+  // document 위임(멱등) — 부분 로딩(partial-nav)으로 홈이 교체돼도 재배선 불필요.
+  (function () {
+    if (document._ahPrDeleteWired) return;
+    document._ahPrDeleteWired = "1";
+
+    var pendingId = null;
+
+    function q(id) { return document.getElementById(id); }
+    function token() { var el = q("pr-csrf"); return el ? el.value : ""; }
+
+    function closeConfirm() {
+      var m = q("pr-delete-modal");
+      if (!m) return;
+      m.classList.remove("is-open");
+      m.setAttribute("aria-hidden", "true");
+      // 리스트 모달(#pr-modal)이 아직 열려 있으므로 body 스크롤 잠금은 유지한다.
+    }
+
+    function refreshCounts() {
+      var n = document.querySelectorAll("#pr-modal-body .ah-request").length;
+      var empty = q("pr-empty");
+      if (empty) empty.hidden = n !== 0;
+      var badge = q("pr-count");
+      if (badge) badge.textContent = n + "건";
+      var viewall = q("pr-viewall");
+      if (viewall) viewall.textContent = "전체 보기 (" + n + ")";
+    }
+
+    document.addEventListener("click", function (e) {
+      if (!e.target.closest) return;
+
+      // 1) 요청 행의 "삭제" → 확인 모달 열기(대상 id 기억)
+      var del = e.target.closest("[data-pr-delete]");
+      if (del) {
+        pendingId = del.getAttribute("data-pr-delete");
+        var m = q("pr-delete-modal");
+        if (m) {
+          m.classList.add("is-open");
+          m.setAttribute("aria-hidden", "false");
+          document.body.classList.add("ah-modal-open");
+        }
+        return;
+      }
+
+      // 2) 확인 모달의 "삭제" → AJAX 삭제
+      var confirmBtn = e.target.closest("#pr-delete-confirm");
+      if (confirmBtn) {
+        if (!pendingId) return;
+        var id = pendingId;
+        confirmBtn.disabled = true;
+
+        var body = new FormData();
+        body.append("action", "delete");
+        body.append("id", id);
+        body.append("csrfmiddlewaretoken", token());
+
+        fetch(window.location.pathname, {
+          method: "POST",
+          headers: { "X-Requested-With": "XMLHttpRequest", "X-CSRFToken": token() },
+          credentials: "same-origin",
+          body: body,
+        })
+          .then(function (res) {
+            if (res.ok) return res.json().catch(function () { return { ok: true }; });
+            return res.json().then(
+              function (d) { throw new Error(d.error || "삭제에 실패했습니다."); },
+              function () { throw new Error("삭제에 실패했습니다."); }
+            );
+          })
+          .then(function () {
+            var item = q("pr-item-" + id);
+            if (item) item.remove();
+            pendingId = null;
+            refreshCounts();
+            closeConfirm();
+            if (window.ahToast) window.ahToast("제품 추가 요청이 삭제되었습니다.", "success");
+          })
+          .catch(function (err) {
+            if (window.ahToast) window.ahToast(err.message || "삭제에 실패했습니다.", "error");
+          })
+          .then(function () {
+            confirmBtn.disabled = false;
+          });
+        return;
+      }
+    });
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
- 삭제: 브라우저 confirm → 확인 모달, AJAX 삭제로 리스트 모달 유지 + 토스트
- home 뷰: AJAX(X-Requested-With) 요청 시 JsonResponse, 일반 폼은 기존 리다이렉트 폴백
- toast.js: 프로그램적 토스트 API(window.ahToast) 추가(마크업/동작 재사용)
- 요청 리스트 모달 우측 스크롤바를 디자인 시스템 톤(.ah-scroll)으로 개선
<!-- A clear and concise description about the feature -->

## 이슈
close #225 
<!-- Add a issues that referenced this pull request -->
