### PR TITLE
feat: 배너 탭 개편 — 드래그 순서·활성/비활성 탭·수정 모달·썸네일+상세·토글(#226)

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -764,43 +764,82 @@ def product_list(request):
 # 배너 관리 — Banner (목록/추가/삭제). 상세(BannerDetail)는 별도.
 # 기존 common admin 배너 기능(common.admin.admin_views)을 /admin/home 로 이식.
 # ---------------------------------------------------------------------------
-def _parse_order(raw, default=1):
-    """order 입력값을 1 이상의 정수로 정규화한다."""
-    try:
-        value = int(str(raw).strip())
-    except (TypeError, ValueError):
-        return default
-    return value if value >= 1 else default
+def _next_banner_order():
+    """새 배너의 순서 = 현재 최대 order + 1 (항상 마지막에 추가)."""
+    return (Banner.objects.aggregate(m=Max("order"))["m"] or 0) + 1
+
+
+def _reorder_banners(id_list):
+    """드래그로 정한 순서(id 배열)대로 Banner.order 를 1..N 으로 재배정한다.
+
+    order 가 unique 라 중간 값 충돌을 피하려고, 먼저 큰 오프셋 임시값으로 옮긴 뒤
+    최종값(1..N)을 다시 세팅하는 2단계 update 를 한 트랜잭션에서 수행한다.
+    id_list 에 없는(예: 다른 탭) 배너는 기존 상대 순서를 유지해 뒤에 이어 붙인다.
+    """
+    offset = 1_000_000
+    with transaction.atomic():
+        all_banners = list(Banner.objects.select_for_update().all())
+        by_id = {str(b.id): b for b in all_banners}
+        ordered = [by_id[i] for i in id_list if i in by_id]
+        seen = {str(b.id) for b in ordered}
+        remaining = [b for b in all_banners if str(b.id) not in seen]
+        final = ordered + remaining
+        for idx, banner in enumerate(final):
+            Banner.objects.filter(id=banner.id).update(order=offset + idx + 1)
+        for idx, banner in enumerate(final):
+            Banner.objects.filter(id=banner.id).update(order=idx + 1)
 
 
 def banner_list(request):
-    """배너 관리 — 목록/추가/삭제.
+    """배너 관리 — 활성/비활성 탭 목록 + 추가/수정/삭제/순서변경/토글.
 
     이미지는 common.utils.upload_banner_to_s3 로 S3 업로드 후 URL 을 저장한다.
-    Banner.order 는 고유(unique)라 중복 시 IntegrityError → 에러 메시지로 안내한다.
-    (배너별 상세 이미지 관리는 banner_detail_* 뷰에서 담당)
+    - create: 썸네일(image) + 선택 상세 이미지(detail_image). order 는 항상 마지막(max+1).
+    - update: 썸네일 교체(선택).
+    - toggle_active / reorder: AJAX(X-Requested-With)면 JSON 으로 응답해 화면을 유지한다.
+    - detail_create/detail_delete: 상세 이미지 관리(순서는 자동 max+1).
+    Banner.order 는 unique 라 순서 재배정 시 2단계 update(_reorder_banners)로 충돌을 피한다.
     """
     if request.method == "POST":
         action = request.POST.get("action", "")
+        is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
         if action == "create":
             image = request.FILES.get("image")
-            order = _parse_order(request.POST.get("order"))
-            dup_msg = f"순서 {order}은(는) 이미 사용 중입니다. 다른 순서를 입력해주세요."
             if not image:
-                messages.error(request, "배너 이미지를 선택해주세요.")
-            elif Banner.objects.filter(order=order).exists():
-                # 중복이면 S3 업로드 전에 막아 불필요한 업로드/고아 파일을 피한다.
-                messages.error(request, dup_msg)
+                messages.error(request, "썸네일 이미지를 선택해주세요.")
+                return redirect("admin_home_banner")
+            image_url = upload_banner_to_s3(image)
+            detail_image = request.FILES.get("detail_image")
+            detail_url = upload_banner_to_s3(detail_image) if detail_image else None
+            try:
+                with transaction.atomic():
+                    banner = Banner.objects.create(
+                        image_url=image_url, order=_next_banner_order()
+                    )
+                    if detail_url:
+                        BannerDetail.objects.create(
+                            banner=banner, detail_image_url=detail_url, order=1
+                        )
+                messages.success(request, "배너가 추가되었습니다.")
+            except IntegrityError:
+                # 동시 요청 경합 등으로 order 가 중복된 경우의 안전망
+                messages.error(request, "배너 추가 중 순서 충돌이 발생했습니다. 다시 시도해주세요.")
+            return redirect("admin_home_banner")
+
+        if action == "update":
+            try:
+                banner = Banner.objects.get(id=request.POST.get("id", ""))
+            except (Banner.DoesNotExist, ValueError):
+                messages.error(request, "배너를 찾을 수 없습니다.")
+                return redirect("admin_home_banner")
+            image = request.FILES.get("image")
+            if image:
+                banner.image_url = upload_banner_to_s3(image)
+                banner.save(update_fields=["image_url"])
+                messages.success(request, f"배너 #{banner.id} 썸네일이 교체되었습니다.")
             else:
-                image_url = upload_banner_to_s3(image)
-                try:
-                    with transaction.atomic():
-                        Banner.objects.create(image_url=image_url, order=order)
-                    messages.success(request, "배너가 추가되었습니다.")
-                except IntegrityError:
-                    # 동시 요청 경합 등으로 order 가 중복된 경우의 안전망
-                    messages.error(request, dup_msg)
+                messages.info(request, "변경할 썸네일이 없습니다.")
             return redirect("admin_home_banner")
 
         if action == "delete":
@@ -815,12 +854,31 @@ def banner_list(request):
             try:
                 banner = Banner.objects.get(id=request.POST.get("id", ""))
             except (Banner.DoesNotExist, ValueError):
+                if is_ajax:
+                    return JsonResponse(
+                        {"ok": False, "error": "배너를 찾을 수 없습니다."}, status=404
+                    )
                 messages.error(request, "배너를 찾을 수 없습니다.")
                 return redirect("admin_home_banner")
             banner.is_active = not banner.is_active
             banner.save(update_fields=["is_active"])
+            if is_ajax:
+                return JsonResponse({"ok": True, "is_active": banner.is_active})
             state = "노출" if banner.is_active else "숨김"
             messages.success(request, f"배너 #{banner.id}를 {state} 상태로 변경했습니다.")
+            return redirect("admin_home_banner")
+
+        if action == "reorder":
+            ids = [i for i in request.POST.getlist("order[]") if i.strip()]
+            try:
+                _reorder_banners(ids)
+                if is_ajax:
+                    return JsonResponse({"ok": True})
+                messages.success(request, "배너 순서가 변경되었습니다.")
+            except Exception as e:
+                if is_ajax:
+                    return JsonResponse({"ok": False, "error": str(e)}, status=400)
+                messages.error(request, f"순서 변경에 실패했습니다: {e}")
             return redirect("admin_home_banner")
 
         if action == "detail_create":
@@ -830,27 +888,22 @@ def banner_list(request):
                 messages.error(request, "배너를 찾을 수 없습니다.")
                 return redirect("admin_home_banner")
             image = request.FILES.get("detail_image")
-            order = _parse_order(request.POST.get("order"))
-            dup_msg = (
-                f"배너 #{banner.id}에 순서 {order}은(는) 이미 사용 중입니다. "
-                "다른 순서를 입력해주세요."
-            )
             if not image:
                 messages.error(request, "상세 이미지를 선택해주세요.")
-            elif BannerDetail.objects.filter(banner=banner, order=order).exists():
-                messages.error(request, dup_msg)
-            else:
-                detail_image_url = upload_banner_to_s3(image)
-                try:
-                    with transaction.atomic():
-                        BannerDetail.objects.create(
-                            banner=banner,
-                            detail_image_url=detail_image_url,
-                            order=order,
-                        )
-                    messages.success(request, "상세 이미지가 추가되었습니다.")
-                except IntegrityError:
-                    messages.error(request, dup_msg)
+                return redirect("admin_home_banner")
+            existing = BannerDetail.objects.filter(banner=banner)
+            next_detail_order = (existing.aggregate(m=Max("order"))["m"] or 0) + 1
+            detail_image_url = upload_banner_to_s3(image)
+            try:
+                with transaction.atomic():
+                    BannerDetail.objects.create(
+                        banner=banner,
+                        detail_image_url=detail_image_url,
+                        order=next_detail_order,
+                    )
+                messages.success(request, "상세 이미지가 추가되었습니다.")
+            except IntegrityError:
+                messages.error(request, "상세 이미지 순서 충돌이 발생했습니다. 다시 시도해주세요.")
             return redirect("admin_home_banner")
 
         if action == "detail_delete":
@@ -864,12 +917,17 @@ def banner_list(request):
         messages.error(request, "알 수 없는 요청입니다.")
         return redirect("admin_home_banner")
 
-    banners = Banner.objects.prefetch_related("details").all()
-    next_order = (Banner.objects.aggregate(m=Max("order"))["m"] or 0) + 1
+    banners = list(Banner.objects.prefetch_related("details").all())
+    active_banners = [b for b in banners if b.is_active]
+    inactive_banners = [b for b in banners if not b.is_active]
     return _ah_render(
         request,
         "admin_home/banner_list.html",
-        {"banners": banners, "next_order": next_order},
+        {
+            "active_banners": active_banners,
+            "inactive_banners": inactive_banners,
+            "banner_count": len(banners),
+        },
     )
 
 

--- a/products/templates/admin_home/banner_list.html
+++ b/products/templates/admin_home/banner_list.html
@@ -1,9 +1,11 @@
 {% extends base_template|default:"admin_home/base.html" %}
 {% comment %}
-  배너 관리 — 목록/추가/삭제. (기존 common admin 배너 기능 이식)
-  단일 뷰(banner_list)에서 POST action(create/delete)으로 분기한다.
-  이미지는 S3 업로드(upload_banner_to_s3) 후 URL 저장, order 는 고유(unique).
-  상세 이미지(BannerDetail) 관리는 별도 태스크에서 각 배너 카드에 추가된다.
+  배너 관리 — 활성/비활성 탭 + 드래그 순서변경 + 수정 모달.
+  · 추가: 토프바 "＋ 배너 추가" → #banner-create-modal (썸네일 + 선택 상세 이미지, 순서 자동 마지막).
+  · 목록: 활성/비활성 탭(패널). 활성 패널은 드래그로 순서 변경(AJAX reorder).
+  · 각 카드: 썸네일/메타 클릭 → 수정 모달(썸네일 교체·상세 이미지·삭제), 토글 스위치 → AJAX 활성/비활성.
+  단일 뷰(banner_list)에서 POST action(create/update/delete/toggle_active/reorder/detail_*)으로 분기.
+  toggle_active·reorder 는 AJAX(JSON) 로 응답해 화면을 유지한다.
 {% endcomment %}
 
 {% block title %}배너 · DASII{% endblock %}
@@ -14,12 +16,39 @@
 
 {% block extra_head %}
 <style>
-  /* 배너 카드 — 디자인 시스템 토큰만 사용 */
-  .ah-banner {
+  /* 탭 (활성/비활성) */
+  .ah-tabs {
+    display: inline-flex;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-pill);
+    margin-bottom: var(--space-4);
+  }
+  .ah-tab {
+    padding: var(--space-1) var(--space-4);
+    border: none;
+    background: transparent;
+    color: var(--text-on-glass);
+    font-size: var(--fs-text-sm);
+    font-weight: var(--font-weight-bold);
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: background var(--transition-base);
+  }
+  .ah-tab.is-active {
+    background: var(--glass-bg-strong);
+    box-shadow: var(--shadow-inset-highlight);
+  }
+
+  /* 배너 카드(행) */
+  .ah-banner-list { display: flex; flex-direction: column; gap: var(--space-2); }
+  .ah-banner-card {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: var(--space-3);
-    padding: var(--space-3);
+    padding: var(--space-2) var(--space-3);
     background: var(--glass-bg);
     -webkit-backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
     backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
@@ -28,39 +57,75 @@
     box-shadow: var(--shadow-glass), var(--shadow-inset-highlight);
     color: var(--text-on-glass);
   }
-  .ah-banner__header {
+  .ah-banner-card.is-dragging { opacity: 0.5; }
+  .ah-banner-card__grip {
+    cursor: grab;
+    color: var(--glass-highlight);
+    font-size: var(--fs-text-lg);
+    line-height: 1;
+    padding: 0 var(--space-1);
+    flex: none;
+  }
+  /* 비활성 탭은 드래그 불가 → 그립 숨김 */
+  [data-banner-panel="inactive"] .ah-banner-card__grip { display: none; }
+  .ah-banner-card__main {
+    flex: 1 1 auto;
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    flex-wrap: wrap;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
   }
+  .ah-banner-card__thumb {
+    height: 56px;
+    max-width: 140px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--glass-border);
+    object-fit: cover;
+    flex: none;
+  }
+  .ah-banner-card__meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+
+  /* 토글 스위치 */
+  .ah-switch { display: inline-flex; align-items: center; gap: var(--space-2); cursor: pointer; user-select: none; flex: none; }
+  .ah-switch__input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+  .ah-switch__track {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+    background: var(--glass-border-strong);
+    border-radius: var(--radius-pill);
+    transition: background var(--transition-base);
+  }
+  .ah-switch__thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: var(--color-gray-0);
+    border-radius: var(--radius-pill);
+    box-shadow: var(--shadow-glass);
+    transition: transform var(--transition-base);
+  }
+  .ah-switch__input:checked + .ah-switch__track { background: var(--brand-primary); }
+  .ah-switch__input:checked + .ah-switch__track .ah-switch__thumb { transform: translateX(20px); }
+  .ah-switch__input:focus-visible + .ah-switch__track { outline: 2px solid var(--brand-secondary); outline-offset: 2px; }
+  .ah-switch__label { color: var(--glass-highlight); min-width: 3.2em; }
+
+  /* 수정 모달 — 썸네일/상세 이미지 (기존 스타일 유지) */
   .ah-banner__thumb {
     height: 80px;
-    max-width: 200px;
+    max-width: 220px;
     border-radius: var(--radius-md);
     border: 1px solid var(--glass-border);
     object-fit: cover;
-  }
-  .ah-banner__meta {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-  .ah-banner__badges {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    flex-wrap: wrap;
-  }
-  .ah-banner__actions { margin-left: auto; display: flex; gap: var(--space-2); }
-
-  /* 상세 이미지 섹션 */
-  .ah-banner__details {
-    border-top: 1px dashed var(--glass-border);
-    padding-top: var(--space-3);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
   }
   .ah-detail-list { display: flex; flex-wrap: wrap; gap: var(--space-2); }
   .ah-detail-item { position: relative; display: inline-block; }
@@ -70,11 +135,7 @@
     border: 1px solid var(--glass-border);
     object-fit: cover;
   }
-  .ah-detail-item__order {
-    position: absolute;
-    top: var(--space-1);
-    left: var(--space-1);
-  }
+  .ah-detail-item__order { position: absolute; top: var(--space-1); left: var(--space-1); }
   .ah-detail-item__del {
     position: absolute;
     top: var(--space-1);
@@ -89,22 +150,12 @@
     border-radius: var(--radius-pill);
     background: var(--color-error);
     color: var(--color-gray-0);
-    font-size: var(--fs-text-sm); /* 18px floor */
+    font-size: var(--fs-text-sm);
     line-height: 1;
     cursor: pointer;
   }
-  .ah-detail-add {
-    display: flex;
-    align-items: flex-end;
-    gap: var(--space-2);
-    flex-wrap: wrap;
-  }
-
-  /* 파일 입력 — 18px 하한 유지, 유리 톤 */
-  .ah-file {
-    font-size: var(--fs-text-sm);
-    color: var(--text-on-glass);
-  }
+  .ah-detail-add { display: flex; align-items: flex-end; gap: var(--space-2); flex-wrap: wrap; }
+  .ah-file { font-size: var(--fs-text-sm); color: var(--text-on-glass); }
   .ah-file::file-selector-button {
     font-size: var(--fs-text-sm);
     font-weight: var(--font-weight-bold);
@@ -116,10 +167,9 @@
     color: var(--text-on-glass);
     cursor: pointer;
   }
-  .ah-order-input { max-width: 8rem; }
 
   @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-    .ah-banner {
+    .ah-banner-card {
       background: var(--glass-bg-fallback);
       color: var(--text-default);
       border-color: var(--color-gray-200);
@@ -129,7 +179,10 @@
 {% endblock %}
 
 {% block content %}
-{# 배너 추가 모달 — 목록 헤더 ＋ 버튼으로 열림 #}
+{# AJAX(토글/순서변경)용 CSRF 토큰 #}
+<input type="hidden" id="banner-csrf" value="{{ csrf_token }}" />
+
+{# 배너 추가 모달 — 썸네일 + 선택 상세 이미지. 순서는 자동으로 마지막에 추가된다. #}
 <div class="ah-modal" id="banner-create-modal" aria-hidden="true">
   <div class="ah-modal__overlay" data-modal-close></div>
   <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
@@ -147,10 +200,10 @@
           <input class="ah-file" type="file" id="banner-image" name="image" accept="image/*" required />
         </div>
         <div class="ah-field">
-          <label class="ah-label" for="banner-order">순서</label>
-          <input class="ah-input ah-order-input" type="number" id="banner-order" name="order"
-                 value="{{ next_order }}" min="1" />
+          <label class="ah-label" for="banner-detail-image">상세 이미지 <span class="text-muted">(선택)</span></label>
+          <input class="ah-file" type="file" id="banner-detail-image" name="detail_image" accept="image/*" />
         </div>
+        <p class="text-caption" style="color: var(--glass-highlight);">순서는 자동으로 맨 마지막에 추가됩니다.</p>
         <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
           <button type="button" class="btn btn-glass" data-modal-close>취소</button>
           <button type="submit" class="btn btn-primary">배너 등록</button>
@@ -160,94 +213,213 @@
   </div>
 </div>
 
-<section class="reveal">
-  <div style="margin-bottom: var(--space-3);">
-    <h2 class="text-title-sm">
-      배너 목록 <span class="text-muted">({{ banners|length }})</span>
-    </h2>
-  </div>
+{# 수정 모달 — 배너 1개당 1개 (활성/비활성 모두) #}
+{% for b in active_banners %}{% include "admin_home/components/_banner_edit_modal.html" with b=b %}{% endfor %}
+{% for b in inactive_banners %}{% include "admin_home/components/_banner_edit_modal.html" with b=b %}{% endfor %}
 
-  {% if banners %}
-  <div class="ah-records" data-reveal-stagger>
-    {% for banner in banners %}
-    <div class="ah-banner reveal">
-      <div class="ah-banner__header">
-        <img class="ah-banner__thumb" src="{{ banner.image_url }}" alt="배너 #{{ banner.id }} 썸네일" />
+{# 탭 (활성/비활성) #}
+<div class="ah-tabs reveal" role="tablist" aria-label="배너 상태">
+  <button type="button" class="ah-tab is-active" data-banner-tab="active" role="tab">
+    활성 (<span data-count-active>{{ active_banners|length }}</span>)
+  </button>
+  <button type="button" class="ah-tab" data-banner-tab="inactive" role="tab">
+    비활성 (<span data-count-inactive>{{ inactive_banners|length }}</span>)
+  </button>
+</div>
 
-        <div class="ah-banner__meta">
-          <p class="text-body">배너 #{{ banner.id }}</p>
-          <div class="ah-banner__badges">
-            <span class="ah-badge ah-badge--neutral">순서 {{ banner.order }}</span>
-            {% if banner.is_active %}
-            <span class="ah-badge ah-badge--ok">활성</span>
-            {% else %}
-            <span class="ah-badge ah-badge--neutral">비활성</span>
-            {% endif %}
-            <span class="ah-badge ah-badge--neutral">상세 {{ banner.details.count }}</span>
-          </div>
-        </div>
-
-        <div class="ah-banner__actions">
-          <form method="post">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="toggle_active" />
-            <input type="hidden" name="id" value="{{ banner.id }}" />
-            <button type="submit" class="btn btn-glass">
-              {% if banner.is_active %}숨기기{% else %}노출하기{% endif %}
-            </button>
-          </form>
-          <form method="post"
-                onsubmit="return confirm('이 배너와 하위 상세 이미지가 모두 삭제됩니다. 계속할까요?');">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="delete" />
-            <input type="hidden" name="id" value="{{ banner.id }}" />
-            <button type="submit" class="btn btn-danger">삭제</button>
-          </form>
-        </div>
-      </div>
-
-      {# 상세 이미지 — 목록/추가/삭제 #}
-      <div class="ah-banner__details">
-        <p class="text-body-sm text-muted">상세 이미지</p>
-
-        {% if banner.details.all %}
-        <div class="ah-detail-list">
-          {% for detail in banner.details.all %}
-          <div class="ah-detail-item">
-            <img class="ah-detail-item__img" src="{{ detail.detail_image_url }}" alt="상세 이미지 순서 {{ detail.order }}" />
-            <span class="ah-badge ah-badge--neutral ah-detail-item__order">{{ detail.order }}</span>
-            <form method="post" onsubmit="return confirm('이 상세 이미지를 삭제할까요?');">
-              {% csrf_token %}
-              <input type="hidden" name="action" value="detail_delete" />
-              <input type="hidden" name="id" value="{{ detail.id }}" />
-              <button type="submit" class="ah-detail-item__del" aria-label="상세 이미지 삭제" title="삭제">&times;</button>
-            </form>
-          </div>
-          {% endfor %}
-        </div>
-        {% endif %}
-
-        <form method="post" enctype="multipart/form-data" class="ah-detail-add">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="detail_create" />
-          <input type="hidden" name="banner_id" value="{{ banner.id }}" />
-          <div class="ah-field">
-            <label class="ah-label" for="detail-image-{{ banner.id }}">상세 이미지</label>
-            <input class="ah-file" type="file" id="detail-image-{{ banner.id }}" name="detail_image" accept="image/*" required />
-          </div>
-          <div class="ah-field">
-            <label class="ah-label" for="detail-order-{{ banner.id }}">순서</label>
-            <input class="ah-input ah-order-input" type="number" id="detail-order-{{ banner.id }}"
-                   name="order" value="{{ banner.details.count|add:1 }}" min="1" />
-          </div>
-          <button type="submit" class="btn btn-glass">상세 추가</button>
-        </form>
-      </div>
-    </div>
+{# 활성 패널 — 드래그로 순서 변경 #}
+<section data-banner-panel="active" class="reveal">
+  <div class="ah-banner-list" data-banner-list>
+    {% for b in active_banners %}
+    {% include "admin_home/components/_banner_card.html" with b=b draggable=True %}
     {% endfor %}
   </div>
-  {% else %}
-  <p class="ah-record-empty text-body">등록된 배너가 없습니다. 위에서 첫 배너를 추가해보세요.</p>
-  {% endif %}
+  <p class="ah-record-empty text-body" data-banner-empty {% if active_banners %}hidden{% endif %}>
+    활성 배너가 없습니다. 우측 상단 ＋ 배너 추가 또는 비활성 탭에서 토글로 활성화하세요.
+  </p>
 </section>
+
+{# 비활성 패널 #}
+<section data-banner-panel="inactive" class="reveal" hidden>
+  <div class="ah-banner-list" data-banner-list>
+    {% for b in inactive_banners %}
+    {% include "admin_home/components/_banner_card.html" with b=b %}
+    {% endfor %}
+  </div>
+  <p class="ah-record-empty text-body" data-banner-empty {% if inactive_banners %}hidden{% endif %}>
+    비활성 배너가 없습니다.
+  </p>
+</section>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  // 배너 탭/드래그 순서변경/토글 — document 위임(멱등). 부분 로딩으로 교체돼도 재배선 불필요.
+  (function () {
+    if (document._ahBannerWired) return;
+    document._ahBannerWired = "1";
+
+    function token() {
+      var el = document.getElementById("banner-csrf");
+      return el ? el.value : "";
+    }
+
+    function post(action, extra) {
+      var body = new FormData();
+      body.append("action", action);
+      body.append("csrfmiddlewaretoken", token());
+      if (extra) extra(body);
+      return fetch(window.location.pathname, {
+        method: "POST",
+        headers: { "X-Requested-With": "XMLHttpRequest", "X-CSRFToken": token() },
+        credentials: "same-origin",
+        body: body,
+      }).then(function (res) {
+        if (res.ok) return res.json().catch(function () { return { ok: true }; });
+        return res.json().then(
+          function (d) { throw new Error(d.error || "요청 실패"); },
+          function () { throw new Error("요청 실패"); }
+        );
+      });
+    }
+
+    function panelList(name) {
+      var p = document.querySelector('[data-banner-panel="' + name + '"] [data-banner-list]');
+      return p;
+    }
+
+    function refreshCountsAndEmpty() {
+      ["active", "inactive"].forEach(function (name) {
+        var list = panelList(name);
+        if (!list) return;
+        var n = list.querySelectorAll(".ah-banner-card").length;
+        var counter = document.querySelector("[data-count-" + name + "]");
+        if (counter) counter.textContent = n;
+        var empty = document.querySelector(
+          '[data-banner-panel="' + name + '"] [data-banner-empty]'
+        );
+        if (empty) empty.hidden = n !== 0;
+      });
+    }
+
+    // 활성 패널의 카드 순서대로 [data-order] 라벨을 1..N 으로 갱신
+    function relabelActiveOrder() {
+      var list = panelList("active");
+      if (!list) return;
+      var cards = list.querySelectorAll(".ah-banner-card");
+      cards.forEach(function (card, i) {
+        var o = card.querySelector("[data-order]");
+        if (o) o.textContent = i + 1;
+      });
+    }
+
+    /* ---- 탭 전환 ---- */
+    document.addEventListener("click", function (e) {
+      var tab = e.target.closest ? e.target.closest("[data-banner-tab]") : null;
+      if (!tab) return;
+      var name = tab.getAttribute("data-banner-tab");
+      document.querySelectorAll("[data-banner-tab]").forEach(function (t) {
+        t.classList.toggle("is-active", t === tab);
+      });
+      document.querySelectorAll("[data-banner-panel]").forEach(function (p) {
+        p.hidden = p.getAttribute("data-banner-panel") !== name;
+      });
+    });
+
+    /* ---- 토글(활성/비활성) ---- */
+    document.addEventListener("change", function (e) {
+      var sw = e.target.closest ? e.target.closest("[data-banner-toggle]") : null;
+      if (!sw) return;
+      var id = sw.getAttribute("data-banner-toggle");
+      var want = sw.checked;
+      sw.disabled = true;
+      post("toggle_active", function (b) { b.append("id", id); })
+        .then(function (data) {
+          var active = data.is_active;
+          var card = document.querySelector('.ah-banner-card[data-banner-id="' + id + '"]');
+          var target = panelList(active ? "active" : "inactive");
+          if (card && target) {
+            card.draggable = !!active;
+            target.appendChild(card);
+            var label = card.querySelector(".ah-switch__label");
+            if (label) label.textContent = active ? "활성" : "비활성";
+          }
+          refreshCountsAndEmpty();
+          relabelActiveOrder();
+          if (window.ahToast) {
+            window.ahToast(active ? "배너를 활성화했습니다." : "배너를 비활성화했습니다.", "success");
+          }
+        })
+        .catch(function (err) {
+          sw.checked = !want; // 실패 시 원복
+          if (window.ahToast) window.ahToast(err.message || "변경에 실패했습니다.", "error");
+        })
+        .then(function () { sw.disabled = false; });
+    });
+
+    /* ---- 드래그 순서변경 (활성 패널) ---- */
+    var dragging = null;
+
+    function afterElement(list, y) {
+      var els = [].slice.call(
+        list.querySelectorAll(".ah-banner-card:not(.is-dragging)")
+      );
+      var closest = { offset: -Infinity, el: null };
+      els.forEach(function (child) {
+        var box = child.getBoundingClientRect();
+        var offset = y - box.top - box.height / 2;
+        if (offset < 0 && offset > closest.offset) closest = { offset: offset, el: child };
+      });
+      return closest.el;
+    }
+
+    document.addEventListener("dragstart", function (e) {
+      var card = e.target.closest ? e.target.closest(".ah-banner-card") : null;
+      if (!card || !card.draggable) return;
+      dragging = card;
+      card.classList.add("is-dragging");
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = "move";
+        try { e.dataTransfer.setData("text/plain", card.getAttribute("data-banner-id")); } catch (_) {}
+      }
+    });
+
+    document.addEventListener("dragover", function (e) {
+      if (!dragging) return;
+      var list = e.target.closest
+        ? e.target.closest('[data-banner-panel="active"] [data-banner-list]')
+        : null;
+      if (!list) return;
+      e.preventDefault();
+      var after = afterElement(list, e.clientY);
+      if (after == null) list.appendChild(dragging);
+      else list.insertBefore(dragging, after);
+    });
+
+    document.addEventListener("dragend", function () {
+      if (!dragging) return;
+      dragging.classList.remove("is-dragging");
+      dragging = null;
+      persistOrder();
+    });
+
+    function persistOrder() {
+      var list = panelList("active");
+      if (!list) return;
+      var ids = [].slice.call(list.querySelectorAll(".ah-banner-card")).map(function (c) {
+        return c.getAttribute("data-banner-id");
+      });
+      post("reorder", function (b) {
+        ids.forEach(function (id) { b.append("order[]", id); });
+      })
+        .then(function () {
+          relabelActiveOrder();
+          if (window.ahToast) window.ahToast("배너 순서가 저장되었습니다.", "success");
+        })
+        .catch(function (err) {
+          if (window.ahToast) window.ahToast(err.message || "순서 저장에 실패했습니다.", "error");
+        });
+    }
+  })();
+</script>
 {% endblock %}

--- a/products/templates/admin_home/components/_banner_card.html
+++ b/products/templates/admin_home/components/_banner_card.html
@@ -1,0 +1,21 @@
+{% comment %}
+  배너 카드 — 그립(드래그 순서변경) + 썸네일/메타(클릭 → 수정 모달) + 활성 토글.
+  · draggable=True 로 include 하면 드래그 가능(활성 탭). 비활성 탭은 그립을 CSS 로 숨긴다.
+  · 토글/드래그/수정은 banner_list.html 의 extra_js 가 위임 처리한다.
+{% endcomment %}
+<div class="ah-banner-card reveal" data-banner-id="{{ b.id }}"{% if draggable %} draggable="true"{% endif %}>
+  <span class="ah-banner-card__grip" aria-hidden="true" title="드래그하여 순서 변경">⠿</span>
+  <button type="button" class="ah-banner-card__main" data-modal-open="banner-edit-{{ b.id }}"
+          title="클릭하여 수정">
+    <img class="ah-banner-card__thumb" src="{{ b.image_url }}" alt="배너 #{{ b.id }} 썸네일" />
+    <span class="ah-banner-card__meta">
+      <span class="text-body">배너 #{{ b.id }}</span>
+      <span class="text-body-sm text-muted">순서 <span data-order>{{ b.order }}</span> · 상세 {{ b.details.count }}장</span>
+    </span>
+  </button>
+  <label class="ah-switch" title="활성/비활성 전환">
+    <input type="checkbox" class="ah-switch__input" data-banner-toggle="{{ b.id }}"{% if b.is_active %} checked{% endif %} />
+    <span class="ah-switch__track"><span class="ah-switch__thumb"></span></span>
+    <span class="ah-switch__label text-body-sm">{% if b.is_active %}활성{% else %}비활성{% endif %}</span>
+  </label>
+</div>

--- a/products/templates/admin_home/components/_banner_edit_modal.html
+++ b/products/templates/admin_home/components/_banner_edit_modal.html
@@ -1,0 +1,79 @@
+{% comment %}
+  배너 수정 모달 (배너 1개당 1개). 카드 클릭(data-modal-open) 으로 열린다.
+  썸네일 교체 · 상세 이미지 관리(추가/삭제) · 배너 삭제. 각 동작은 전체 페이지 POST 로
+  처리되고 리다이렉트 후 토스트로 결과를 안내한다(활성/비활성 토글·순서는 목록에서 AJAX).
+{% endcomment %}
+<div class="ah-modal" id="banner-edit-{{ b.id }}" aria-hidden="true">
+  <div class="ah-modal__overlay" data-modal-close></div>
+  <div class="ah-modal__dialog glass-panel" role="dialog" aria-modal="true"
+       aria-labelledby="banner-edit-{{ b.id }}-title" style="width: min(680px, 100%);">
+    <div class="ah-modal__head">
+      <h2 id="banner-edit-{{ b.id }}-title" class="text-title-md">배너 #{{ b.id }} 수정</h2>
+      <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
+    </div>
+    <div class="ah-modal__body">
+      {# 썸네일 교체 #}
+      <div class="ah-field">
+        <span class="ah-label">현재 썸네일</span>
+        <img class="ah-banner__thumb" src="{{ b.image_url }}" alt="배너 #{{ b.id }} 썸네일" />
+      </div>
+      <form method="post" enctype="multipart/form-data" class="ah-stack">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="update" />
+        <input type="hidden" name="id" value="{{ b.id }}" />
+        <div class="ah-field">
+          <label class="ah-label" for="banner-edit-image-{{ b.id }}">썸네일 교체</label>
+          <input class="ah-file" type="file" id="banner-edit-image-{{ b.id }}" name="image" accept="image/*" />
+        </div>
+        <div style="display:flex; justify-content:flex-end;">
+          <button type="submit" class="btn btn-primary">썸네일 저장</button>
+        </div>
+      </form>
+
+      {# 상세 이미지 관리 #}
+      <div class="ah-formsection">
+        <h3 class="text-title-sm">상세 이미지</h3>
+      </div>
+      {% if b.details.all %}
+      <div class="ah-detail-list">
+        {% for d in b.details.all %}
+        <div class="ah-detail-item">
+          <img class="ah-detail-item__img" src="{{ d.detail_image_url }}" alt="상세 이미지 순서 {{ d.order }}" />
+          <span class="ah-badge ah-badge--neutral ah-detail-item__order">{{ d.order }}</span>
+          <form method="post" onsubmit="return confirm('이 상세 이미지를 삭제할까요?');">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="detail_delete" />
+            <input type="hidden" name="id" value="{{ d.id }}" />
+            <button type="submit" class="ah-detail-item__del" aria-label="상세 이미지 삭제" title="삭제">&times;</button>
+          </form>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-body-sm text-muted">등록된 상세 이미지가 없습니다.</p>
+      {% endif %}
+
+      <form method="post" enctype="multipart/form-data" class="ah-detail-add">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="detail_create" />
+        <input type="hidden" name="banner_id" value="{{ b.id }}" />
+        <div class="ah-field">
+          <label class="ah-label" for="banner-edit-detail-{{ b.id }}">상세 이미지 추가</label>
+          <input class="ah-file" type="file" id="banner-edit-detail-{{ b.id }}" name="detail_image" accept="image/*" required />
+        </div>
+        <button type="submit" class="btn btn-glass">상세 추가</button>
+      </form>
+
+      {# 배너 삭제 #}
+      <div style="margin-top: var(--space-4); padding-top: var(--space-3); border-top: 1px solid var(--glass-border); display:flex; justify-content:flex-end;">
+        <form method="post"
+              onsubmit="return confirm('이 배너와 하위 상세 이미지가 모두 삭제됩니다. 계속할까요?');">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="delete" />
+          <input type="hidden" name="id" value="{{ b.id }}" />
+          <button type="submit" class="btn btn-danger">이 배너 삭제</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
- 활성/비활성 목록을 탭으로 분리, 활성 패널은 드래그앤드롭으로 순서 변경(AJAX)
- Banner.order 재배정은 임시 오프셋 → 최종값 2단계 update 로 unique 충돌 방지
- 새 배너는 항상 마지막 순서(max+1)로 추가, 추가 시 썸네일 + 상세 이미지 함께 입력
- 각 배너 카드 클릭 → 수정 모달(썸네일 교체·상세 이미지 관리·삭제)
- 활성/비활성을 토글 스위치로 제어(AJAX, 실패 시 원복) + 토스트 피드백
- toggle_active·reorder 는 X-Requested-With 시 JsonResponse 로 응답
<!-- A clear and concise description about the feature -->

## 이슈
close #226 
<!-- Add a issues that referenced this pull request -->
