### PR TITLE
Feat/#227 banner followup

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -790,6 +790,28 @@ def _reorder_banners(id_list):
             Banner.objects.filter(id=banner.id).update(order=idx + 1)
 
 
+def _reorder_banner_details(banner_id, id_list):
+    """한 배너의 상세 이미지(BannerDetail)를 드래그 순서(id 배열)대로 1..N 재배정한다.
+
+    unique_together(banner, order) 라 배너 순서 재배정과 동일하게 2단계 update 로
+    중간 충돌을 피한다. id_list 에 없는 상세는 기존 상대 순서로 뒤에 이어 붙인다.
+    """
+    offset = 1_000_000
+    with transaction.atomic():
+        details = list(
+            BannerDetail.objects.select_for_update().filter(banner_id=banner_id)
+        )
+        by_id = {str(d.id): d for d in details}
+        ordered = [by_id[i] for i in id_list if i in by_id]
+        seen = {str(d.id) for d in ordered}
+        remaining = [d for d in details if str(d.id) not in seen]
+        final = ordered + remaining
+        for idx, detail in enumerate(final):
+            BannerDetail.objects.filter(id=detail.id).update(order=offset + idx + 1)
+        for idx, detail in enumerate(final):
+            BannerDetail.objects.filter(id=detail.id).update(order=idx + 1)
+
+
 def banner_list(request):
     """배너 관리 — 활성/비활성 탭 목록 + 추가/수정/삭제/순서변경/토글.
 
@@ -810,16 +832,18 @@ def banner_list(request):
                 messages.error(request, "썸네일 이미지를 선택해주세요.")
                 return redirect("admin_home_banner")
             image_url = upload_banner_to_s3(image)
-            detail_image = request.FILES.get("detail_image")
-            detail_url = upload_banner_to_s3(detail_image) if detail_image else None
+            # 상세 이미지는 여러 장 가능. 폼에서 드래그로 정한 순서대로 전송되며,
+            # 그 순서대로 BannerDetail.order 를 1..N 으로 부여한다.
+            detail_images = [f for f in request.FILES.getlist("detail_images") if f]
+            detail_urls = [upload_banner_to_s3(f) for f in detail_images]
             try:
                 with transaction.atomic():
                     banner = Banner.objects.create(
                         image_url=image_url, order=_next_banner_order()
                     )
-                    if detail_url:
+                    for idx, detail_url in enumerate(detail_urls, start=1):
                         BannerDetail.objects.create(
-                            banner=banner, detail_image_url=detail_url, order=1
+                            banner=banner, detail_image_url=detail_url, order=idx
                         )
                 messages.success(request, "배너가 추가되었습니다.")
             except IntegrityError:
@@ -887,23 +911,38 @@ def banner_list(request):
             except (Banner.DoesNotExist, ValueError):
                 messages.error(request, "배너를 찾을 수 없습니다.")
                 return redirect("admin_home_banner")
-            image = request.FILES.get("detail_image")
-            if not image:
+            images = [f for f in request.FILES.getlist("detail_image") if f]
+            if not images:
                 messages.error(request, "상세 이미지를 선택해주세요.")
                 return redirect("admin_home_banner")
             existing = BannerDetail.objects.filter(banner=banner)
             next_detail_order = (existing.aggregate(m=Max("order"))["m"] or 0) + 1
-            detail_image_url = upload_banner_to_s3(image)
+            detail_urls = [upload_banner_to_s3(f) for f in images]
             try:
                 with transaction.atomic():
-                    BannerDetail.objects.create(
-                        banner=banner,
-                        detail_image_url=detail_image_url,
-                        order=next_detail_order,
-                    )
+                    for offset, detail_image_url in enumerate(detail_urls):
+                        BannerDetail.objects.create(
+                            banner=banner,
+                            detail_image_url=detail_image_url,
+                            order=next_detail_order + offset,
+                        )
                 messages.success(request, "상세 이미지가 추가되었습니다.")
             except IntegrityError:
                 messages.error(request, "상세 이미지 순서 충돌이 발생했습니다. 다시 시도해주세요.")
+            return redirect("admin_home_banner")
+
+        if action == "detail_reorder":
+            banner_id = request.POST.get("banner_id", "")
+            ids = [i for i in request.POST.getlist("order[]") if i.strip()]
+            try:
+                _reorder_banner_details(banner_id, ids)
+                if is_ajax:
+                    return JsonResponse({"ok": True})
+                messages.success(request, "상세 이미지 순서가 변경되었습니다.")
+            except Exception as e:
+                if is_ajax:
+                    return JsonResponse({"ok": False, "error": str(e)}, status=400)
+                messages.error(request, f"순서 변경에 실패했습니다: {e}")
             return redirect("admin_home_banner")
 
         if action == "detail_delete":

--- a/products/templates/admin_home/banner_list.html
+++ b/products/templates/admin_home/banner_list.html
@@ -58,6 +58,21 @@
     color: var(--text-on-glass);
   }
   .ah-banner-card.is-dragging { opacity: 0.5; }
+  /* 좌측 표시 순번(활성 탭) — 위에서부터 노출되는 순서 */
+  .ah-banner-card__num {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9em;
+    height: 1.9em;
+    border-radius: var(--radius-pill);
+    background: var(--glass-bg-strong);
+    border: 1px solid var(--glass-border);
+    color: var(--glass-highlight);
+    font-weight: var(--font-weight-bold);
+    line-height: 1;
+  }
   .ah-banner-card__grip {
     cursor: grab;
     color: var(--glass-highlight);
@@ -66,8 +81,9 @@
     padding: 0 var(--space-1);
     flex: none;
   }
-  /* 비활성 탭은 드래그 불가 → 그립 숨김 */
-  [data-banner-panel="inactive"] .ah-banner-card__grip { display: none; }
+  /* 비활성 탭은 드래그 불가·순서 무의미 → 그립·순번 숨김 */
+  [data-banner-panel="inactive"] .ah-banner-card__grip,
+  [data-banner-panel="inactive"] .ah-banner-card__num { display: none; }
   .ah-banner-card__main {
     flex: 1 1 auto;
     display: flex;
@@ -128,7 +144,12 @@
     object-fit: cover;
   }
   .ah-detail-list { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+  /* 생성 모달의 상세 이미지 미리보기(드래그로 순서 지정) */
+  .ah-detail-picker { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-2); }
   .ah-detail-item { position: relative; display: inline-block; }
+  /* 드래그 가능한 상세(생성 미리보기 · 수정 모달의 기존 상세) */
+  .ah-detail-item[draggable="true"] { cursor: grab; }
+  .ah-detail-item.is-dragging { opacity: 0.5; }
   .ah-detail-item__img {
     height: 72px;
     border-radius: var(--radius-sm);
@@ -155,6 +176,26 @@
     cursor: pointer;
   }
   .ah-detail-add { display: flex; align-items: flex-end; gap: var(--space-2); flex-wrap: wrap; }
+
+  /* 수정 모달 레이아웃 — 섹션 구획 + 썸네일 교체 행 */
+  .ah-edit-section { padding-top: var(--space-3); border-top: 1px solid var(--glass-border); }
+  .ah-edit-section:first-child { padding-top: 0; border-top: none; }
+  .ah-edit-section__head {
+    display: flex; align-items: baseline; gap: var(--space-2);
+    flex-wrap: wrap; margin-bottom: var(--space-2);
+  }
+  .ah-edit-section__title { margin-bottom: var(--space-2); }
+  .ah-edit-section__head .ah-edit-section__title { margin-bottom: 0; }
+  .ah-edit-thumb { display: flex; align-items: flex-start; gap: var(--space-3); flex-wrap: wrap; }
+  .ah-edit-thumb__ctrl {
+    display: flex; flex-direction: column; gap: var(--space-2);
+    align-items: flex-start; flex: 1 1 220px; min-width: 0;
+  }
+  .ah-edit-footer {
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--glass-border);
+    display: flex; justify-content: flex-end;
+  }
   .ah-file { font-size: var(--fs-text-sm); color: var(--text-on-glass); }
   .ah-file::file-selector-button {
     font-size: var(--fs-text-sm);
@@ -200,13 +241,18 @@
           <input class="ah-file" type="file" id="banner-image" name="image" accept="image/*" required />
         </div>
         <div class="ah-field">
-          <label class="ah-label" for="banner-detail-image">상세 이미지 <span class="text-muted">(선택)</span></label>
-          <input class="ah-file" type="file" id="banner-detail-image" name="detail_image" accept="image/*" />
+          <span class="ah-label">상세 이미지
+            <span class="text-muted">(선택 · 여러 장 · 드래그로 순서 지정)</span></span>
+          {# 선택용 입력. 고른 파일은 아래 미리보기로 쌓이고, 실제 전송은 hidden payload 로 한다. #}
+          <input class="ah-file" type="file" id="banner-detail-pick" accept="image/*" multiple
+                 data-detail-pick />
+          <div class="ah-detail-picker" data-detail-previews hidden></div>
+          {# 미리보기에서 정한 순서대로 파일이 담기는 실제 전송 필드 #}
+          <input type="file" name="detail_images" multiple hidden data-detail-payload />
         </div>
-        <p class="text-caption" style="color: var(--glass-highlight);">순서는 자동으로 맨 마지막에 추가됩니다.</p>
         <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
           <button type="button" class="btn btn-glass" data-modal-close>취소</button>
-          <button type="submit" class="btn btn-primary">배너 등록</button>
+          <button type="submit" class="btn btn-primary">저장</button>
         </div>
       </form>
     </div>
@@ -231,7 +277,7 @@
 <section data-banner-panel="active" class="reveal">
   <div class="ah-banner-list" data-banner-list>
     {% for b in active_banners %}
-    {% include "admin_home/components/_banner_card.html" with b=b draggable=True %}
+    {% include "admin_home/components/_banner_card.html" with b=b draggable=True index=forloop.counter %}
     {% endfor %}
   </div>
   <p class="ah-record-empty text-body" data-banner-empty {% if active_banners %}hidden{% endif %}>
@@ -243,7 +289,7 @@
 <section data-banner-panel="inactive" class="reveal" hidden>
   <div class="ah-banner-list" data-banner-list>
     {% for b in inactive_banners %}
-    {% include "admin_home/components/_banner_card.html" with b=b %}
+    {% include "admin_home/components/_banner_card.html" with b=b index=forloop.counter %}
     {% endfor %}
   </div>
   <p class="ah-record-empty text-body" data-banner-empty {% if inactive_banners %}hidden{% endif %}>
@@ -415,6 +461,148 @@
         .then(function () {
           relabelActiveOrder();
           if (window.ahToast) window.ahToast("배너 순서가 저장되었습니다.", "success");
+        })
+        .catch(function (err) {
+          if (window.ahToast) window.ahToast(err.message || "순서 저장에 실패했습니다.", "error");
+        });
+    }
+
+    /* ---- 생성 모달: 상세 이미지 여러 장 선택 + 드래그로 순서 지정 ----
+       파일 input 은 FileList 를 직접 재정렬할 수 없어, 고른 파일을 배열로 들고
+       미리보기를 드래그로 정렬한 뒤 DataTransfer 로 hidden payload 에 순서대로 담는다. */
+    var createFiles = [];
+    var createObjectUrls = [];
+
+    function payloadEl() { return document.querySelector("[data-detail-payload]"); }
+    function previewsEl() { return document.querySelector("[data-detail-previews]"); }
+
+    function syncCreatePayload() {
+      var payload = payloadEl();
+      if (!payload || typeof DataTransfer === "undefined") return;
+      var dt = new DataTransfer();
+      createFiles.forEach(function (f) { dt.items.add(f); });
+      payload.files = dt.files;
+    }
+
+    function renderCreatePreviews() {
+      var wrap = previewsEl();
+      if (!wrap) return;
+      // 이전에 만든 objectURL 정리(메모리 누수 방지)
+      createObjectUrls.forEach(function (u) { URL.revokeObjectURL(u); });
+      createObjectUrls = [];
+      wrap.innerHTML = "";
+      wrap.hidden = createFiles.length === 0;
+      createFiles.forEach(function (f, i) {
+        var url = URL.createObjectURL(f);
+        createObjectUrls.push(url);
+        var item = document.createElement("div");
+        item.className = "ah-detail-item";
+        item.setAttribute("draggable", "true");
+        item.setAttribute("data-create-idx", i);
+        item.innerHTML =
+          '<img class="ah-detail-item__img" src="' + url + '" alt="상세 미리보기 ' + (i + 1) + '" />' +
+          '<span class="ah-badge ah-badge--neutral ah-detail-item__order">' + (i + 1) + "</span>" +
+          '<button type="button" class="ah-detail-item__del" data-create-remove="' + i +
+          '" aria-label="제거" title="제거">&times;</button>';
+        wrap.appendChild(item);
+      });
+      syncCreatePayload();
+    }
+
+    function resetCreatePicker() {
+      createFiles = [];
+      renderCreatePreviews();
+    }
+
+    // 생성 모달을 열 때마다 이전 선택 초기화(부분 로딩·재오픈 대비)
+    document.addEventListener("click", function (e) {
+      var op = e.target.closest ? e.target.closest('[data-modal-open="banner-create-modal"]') : null;
+      if (op) resetCreatePicker();
+    });
+
+    // 파일 선택 → 배열에 누적 후 미리보기 갱신(input 은 비워 같은 파일 재선택 허용)
+    document.addEventListener("change", function (e) {
+      var pick = e.target.closest ? e.target.closest("[data-detail-pick]") : null;
+      if (!pick) return;
+      Array.prototype.forEach.call(pick.files, function (f) { createFiles.push(f); });
+      pick.value = "";
+      renderCreatePreviews();
+    });
+
+    // 미리보기 개별 제거
+    document.addEventListener("click", function (e) {
+      var rm = e.target.closest ? e.target.closest("[data-create-remove]") : null;
+      if (!rm) return;
+      createFiles.splice(parseInt(rm.getAttribute("data-create-remove"), 10), 1);
+      renderCreatePreviews();
+    });
+
+    /* ---- 상세 이미지 드래그 순서 (생성 미리보기 + 수정 모달) ---- */
+    var detailDrag = null;
+
+    function detailAfter(list, x) {
+      var els = [].slice.call(list.querySelectorAll(".ah-detail-item:not(.is-dragging)"));
+      var closest = { offset: -Infinity, el: null };
+      els.forEach(function (child) {
+        var box = child.getBoundingClientRect();
+        var offset = x - box.left - box.width / 2;
+        if (offset < 0 && offset > closest.offset) closest = { offset: offset, el: child };
+      });
+      return closest.el;
+    }
+
+    document.addEventListener("dragstart", function (e) {
+      var item = e.target.closest ? e.target.closest(".ah-detail-item[draggable='true']") : null;
+      if (!item) return;
+      detailDrag = item;
+      item.classList.add("is-dragging");
+      if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
+    });
+
+    document.addEventListener("dragover", function (e) {
+      if (!detailDrag) return;
+      var list = detailDrag.parentNode;
+      if (!list || !list.contains(e.target)) return;
+      e.preventDefault();
+      var after = detailAfter(list, e.clientX);
+      if (after == null) list.appendChild(detailDrag);
+      else list.insertBefore(detailDrag, after);
+    });
+
+    document.addEventListener("dragend", function (e) {
+      if (!detailDrag) return;
+      var list = detailDrag.parentNode;
+      detailDrag.classList.remove("is-dragging");
+      detailDrag = null;
+      if (!list) return;
+      if (list.hasAttribute("data-detail-previews")) {
+        // 생성 미리보기 — DOM 순서를 파일 배열에 반영
+        var order = [].slice.call(list.querySelectorAll(".ah-detail-item")).map(function (it) {
+          return parseInt(it.getAttribute("data-create-idx"), 10);
+        });
+        createFiles = order.map(function (idx) { return createFiles[idx]; });
+        renderCreatePreviews();
+      } else if (list.hasAttribute("data-detail-reorder")) {
+        // 수정 모달의 기존 상세 — 서버에 AJAX 로 순서 저장
+        persistDetailOrder(list);
+      }
+    });
+
+    function persistDetailOrder(list) {
+      var bannerId = list.getAttribute("data-detail-reorder");
+      var ids = [].slice.call(list.querySelectorAll(".ah-detail-item")).map(function (c) {
+        return c.getAttribute("data-detail-id");
+      });
+      post("detail_reorder", function (b) {
+        b.append("banner_id", bannerId);
+        ids.forEach(function (id) { b.append("order[]", id); });
+      })
+        .then(function () {
+          [].slice.call(list.querySelectorAll(".ah-detail-item")).forEach(function (c, i) {
+            var o = c.querySelector(".ah-detail-item__order");
+            if (o) o.textContent = i + 1;
+          });
+          if (window.ahToast) window.ahToast("상세 이미지 순서가 저장되었습니다.", "success");
         })
         .catch(function (err) {
           if (window.ahToast) window.ahToast(err.message || "순서 저장에 실패했습니다.", "error");

--- a/products/templates/admin_home/components/_banner_card.html
+++ b/products/templates/admin_home/components/_banner_card.html
@@ -1,16 +1,22 @@
 {% comment %}
-  배너 카드 — 그립(드래그 순서변경) + 썸네일/메타(클릭 → 수정 모달) + 활성 토글.
+  배너 카드 — 좌측 순번(활성 탭) + 그립(드래그) + 썸네일/메타(클릭 → 수정 모달) + 활성 토글.
   · draggable=True 로 include 하면 드래그 가능(활성 탭). 비활성 탭은 그립을 CSS 로 숨긴다.
-  · 토글/드래그/수정은 banner_list.html 의 extra_js 가 위임 처리한다.
+  · 활성 탭은 좌측에 "표시 순번"(위에서부터 노출되는 순서)을 붙인다. 드래그/토글 시
+    banner_list.html 의 relabelActiveOrder 가 [data-order] 를 1..N 으로 다시 매긴다.
+  · 배너 구분은 #id·썸네일로 한다(별도 이름 없음).
 {% endcomment %}
 <div class="ah-banner-card reveal" data-banner-id="{{ b.id }}"{% if draggable %} draggable="true"{% endif %}>
+  {# 좌측 순번 — 활성 탭에서만 노출(비활성 패널은 CSS 로 숨김). 토글로 패널 이동 시
+     relabelActiveOrder 가 값을 다시 매긴다. #}
+  <span class="ah-banner-card__num text-body-sm" data-order
+        title="위에서부터 노출되는 순서입니다">{{ index }}</span>
   <span class="ah-banner-card__grip" aria-hidden="true" title="드래그하여 순서 변경">⠿</span>
   <button type="button" class="ah-banner-card__main" data-modal-open="banner-edit-{{ b.id }}"
           title="클릭하여 수정">
     <img class="ah-banner-card__thumb" src="{{ b.image_url }}" alt="배너 #{{ b.id }} 썸네일" />
     <span class="ah-banner-card__meta">
       <span class="text-body">배너 #{{ b.id }}</span>
-      <span class="text-body-sm text-muted">순서 <span data-order>{{ b.order }}</span> · 상세 {{ b.details.count }}장</span>
+      <span class="text-body-sm text-muted">상세 {{ b.details.count }}장</span>
     </span>
   </button>
   <label class="ah-switch" title="활성/비활성 전환">

--- a/products/templates/admin_home/components/_banner_edit_modal.html
+++ b/products/templates/admin_home/components/_banner_edit_modal.html
@@ -1,7 +1,8 @@
 {% comment %}
   배너 수정 모달 (배너 1개당 1개). 카드 클릭(data-modal-open) 으로 열린다.
-  썸네일 교체 · 상세 이미지 관리(추가/삭제) · 배너 삭제. 각 동작은 전체 페이지 POST 로
-  처리되고 리다이렉트 후 토스트로 결과를 안내한다(활성/비활성 토글·순서는 목록에서 AJAX).
+  썸네일 교체 · 상세 이미지 관리(추가/삭제/드래그 순서변경) · 배너 삭제.
+  썸네일 교체·상세 추가·삭제는 전체 페이지 POST(리다이렉트 후 토스트), 상세 순서변경만
+  목록과 동일하게 AJAX(detail_reorder)로 처리해 모달을 유지한다.
 {% endcomment %}
 <div class="ah-modal" id="banner-edit-{{ b.id }}" aria-hidden="true">
   <div class="ah-modal__overlay" data-modal-close></div>
@@ -11,67 +12,76 @@
       <h2 id="banner-edit-{{ b.id }}-title" class="text-title-md">배너 #{{ b.id }} 수정</h2>
       <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
     </div>
-    <div class="ah-modal__body">
-      {# 썸네일 교체 #}
-      <div class="ah-field">
-        <span class="ah-label">현재 썸네일</span>
-        <img class="ah-banner__thumb" src="{{ b.image_url }}" alt="배너 #{{ b.id }} 썸네일" />
-      </div>
-      <form method="post" enctype="multipart/form-data" class="ah-stack">
-        {% csrf_token %}
-        <input type="hidden" name="action" value="update" />
-        <input type="hidden" name="id" value="{{ b.id }}" />
-        <div class="ah-field">
-          <label class="ah-label" for="banner-edit-image-{{ b.id }}">썸네일 교체</label>
-          <input class="ah-file" type="file" id="banner-edit-image-{{ b.id }}" name="image" accept="image/*" />
-        </div>
-        <div style="display:flex; justify-content:flex-end;">
-          <button type="submit" class="btn btn-primary">썸네일 저장</button>
-        </div>
-      </form>
+    <div class="ah-modal__body ah-stack">
+      {# ── 썸네일 ── 현재 이미지 + 교체를 한 줄로 묶어 배치 #}
+      <section class="ah-edit-section">
+        <h3 class="ah-edit-section__title text-title-sm">썸네일</h3>
+        <form method="post" enctype="multipart/form-data" class="ah-edit-thumb">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="update" />
+          <input type="hidden" name="id" value="{{ b.id }}" />
+          <img class="ah-banner__thumb" src="{{ b.image_url }}" alt="배너 #{{ b.id }} 썸네일" />
+          <div class="ah-edit-thumb__ctrl">
+            <label class="ah-label" for="banner-edit-image-{{ b.id }}">이미지 교체</label>
+            <input class="ah-file" type="file" id="banner-edit-image-{{ b.id }}"
+                   name="image" accept="image/*" />
+            <button type="submit" class="btn btn-primary">저장</button>
+          </div>
+        </form>
+      </section>
 
-      {# 상세 이미지 관리 #}
-      <div class="ah-formsection">
-        <h3 class="text-title-sm">상세 이미지</h3>
-      </div>
-      {% if b.details.all %}
-      <div class="ah-detail-list">
-        {% for d in b.details.all %}
-        <div class="ah-detail-item">
-          <img class="ah-detail-item__img" src="{{ d.detail_image_url }}" alt="상세 이미지 순서 {{ d.order }}" />
-          <span class="ah-badge ah-badge--neutral ah-detail-item__order">{{ d.order }}</span>
-          <form method="post" onsubmit="return confirm('이 상세 이미지를 삭제할까요?');">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="detail_delete" />
-            <input type="hidden" name="id" value="{{ d.id }}" />
-            <button type="submit" class="ah-detail-item__del" aria-label="상세 이미지 삭제" title="삭제">&times;</button>
-          </form>
+      {# ── 상세 이미지 ── 드래그로 순서변경 + 추가/삭제 #}
+      <section class="ah-edit-section">
+        <div class="ah-edit-section__head">
+          <h3 class="ah-edit-section__title text-title-sm">상세 이미지</h3>
+          {% if b.details.all %}
+          <span class="text-body-sm text-muted">드래그하여 순서를 바꿀 수 있습니다.</span>
+          {% endif %}
         </div>
-        {% endfor %}
-      </div>
-      {% else %}
-      <p class="text-body-sm text-muted">등록된 상세 이미지가 없습니다.</p>
-      {% endif %}
-
-      <form method="post" enctype="multipart/form-data" class="ah-detail-add">
-        {% csrf_token %}
-        <input type="hidden" name="action" value="detail_create" />
-        <input type="hidden" name="banner_id" value="{{ b.id }}" />
-        <div class="ah-field">
-          <label class="ah-label" for="banner-edit-detail-{{ b.id }}">상세 이미지 추가</label>
-          <input class="ah-file" type="file" id="banner-edit-detail-{{ b.id }}" name="detail_image" accept="image/*" required />
+        {% if b.details.all %}
+        <div class="ah-detail-list" data-detail-reorder="{{ b.id }}">
+          {% for d in b.details.all %}
+          <div class="ah-detail-item" draggable="true" data-detail-id="{{ d.id }}">
+            <img class="ah-detail-item__img" src="{{ d.detail_image_url }}"
+                 alt="상세 이미지 순서 {{ d.order }}" />
+            <span class="ah-badge ah-badge--neutral ah-detail-item__order">{{ d.order }}</span>
+            <form method="post" onsubmit="return confirm('이 상세 이미지를 삭제할까요?');">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="detail_delete" />
+              <input type="hidden" name="id" value="{{ d.id }}" />
+              <button type="submit" class="ah-detail-item__del" aria-label="상세 이미지 삭제"
+                      title="삭제">&times;</button>
+            </form>
+          </div>
+          {% endfor %}
         </div>
-        <button type="submit" class="btn btn-glass">상세 추가</button>
-      </form>
+        {% else %}
+        <p class="text-body-sm text-muted">등록된 상세 이미지가 없습니다.</p>
+        {% endif %}
 
-      {# 배너 삭제 #}
-      <div style="margin-top: var(--space-4); padding-top: var(--space-3); border-top: 1px solid var(--glass-border); display:flex; justify-content:flex-end;">
+        <form method="post" enctype="multipart/form-data" class="ah-detail-add">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="detail_create" />
+          <input type="hidden" name="banner_id" value="{{ b.id }}" />
+          <div class="ah-field">
+            <label class="ah-label" for="banner-edit-detail-{{ b.id }}">
+              상세 이미지 추가 <span class="text-muted">(여러 장 선택 가능)</span>
+            </label>
+            <input class="ah-file" type="file" id="banner-edit-detail-{{ b.id }}"
+                   name="detail_image" accept="image/*" multiple required />
+          </div>
+          <button type="submit" class="btn btn-glass">추가</button>
+        </form>
+      </section>
+
+      {# ── 배너 삭제 ── #}
+      <div class="ah-edit-footer">
         <form method="post"
               onsubmit="return confirm('이 배너와 하위 상세 이미지가 모두 삭제됩니다. 계속할까요?');">
           {% csrf_token %}
           <input type="hidden" name="action" value="delete" />
           <input type="hidden" name="id" value="{{ b.id }}" />
-          <button type="submit" class="btn btn-danger">이 배너 삭제</button>
+          <button type="submit" class="btn btn-danger">삭제</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
- 상세 이미지 다중 입력 + 드래그 순서 지정(생성 전): 배너 추가 모달에서 상세 이미지를 여러 장 선택하고, 등록 전에 리스트에서 드래그로 순서를 정한다. 순서대로 BannerDetail.order 1..N 부여.
- 수정 모달 상세 이미지 드래그 순서 변경: 기존 상세 이미지도 드래그로 순서 변경(AJAX detail_reorder, unique_together(banner, order) 충돌 회피 2단계 재배정).
- 수정 모달 내부 UI 레이아웃 개선: 현재 어색한 배치 정리.
- 리스트 카드 순서 표기 개선: "순서 N" 텍스트 제거 → 좌측 표시 순번으로 대체(+안내 툴팁). 구분은 기존처럼 #id·썸네일 유지, 이름 기능 미도입.
- 워딩 간소화: "이 배너 삭제" → "삭제", 저장 버튼 → "저장".
- admin_home 스코프 내(템플릿 + admin_home_views.py). 모델/마이그레이션 변경 없음.
<!-- A clear and concise description about the feature -->

## 이슈
close #227 
<!-- Add a issues that referenced this pull request -->
