### PR TITLE
fix: admin_home 여러 줄 {# #} 주석이 화면에 렌더되던 문제 수정(#233)

### DIFF
--- a/products/templates/admin_home/components/_banner_card.html
+++ b/products/templates/admin_home/components/_banner_card.html
@@ -6,8 +6,10 @@
   · 배너 구분은 #id·썸네일로 한다(별도 이름 없음).
 {% endcomment %}
 <div class="ah-banner-card reveal" data-banner-id="{{ b.id }}"{% if draggable %} draggable="true"{% endif %}>
-  {# 좌측 순번 — 활성 탭에서만 노출(비활성 패널은 CSS 로 숨김). 토글로 패널 이동 시
-     relabelActiveOrder 가 값을 다시 매긴다. #}
+  {% comment %}
+    좌측 순번 — 활성 탭에서만 노출(비활성 패널은 CSS 로 숨김). 토글로 패널 이동 시
+    relabelActiveOrder 가 값을 다시 매긴다.
+  {% endcomment %}
   <span class="ah-banner-card__num text-body-sm" data-order
         title="위에서부터 노출되는 순서입니다">{{ index }}</span>
   <span class="ah-banner-card__grip" aria-hidden="true" title="드래그하여 순서 변경">⠿</span>

--- a/products/templates/admin_home/product_list.html
+++ b/products/templates/admin_home/product_list.html
@@ -163,8 +163,10 @@
           </div>
         </div>
 
-        {# 이미지 — 기존 이미지는 체크해서 삭제(delete_image_ids[], JS 가 채움),
-           추가는 현재 한 번에 한 장만 지원하므로 단일 파일 입력으로 UI 를 맞춘다. #}
+        {% comment %}
+          이미지 — 기존 이미지는 체크해서 삭제(delete_image_ids[], JS 가 채움),
+          추가는 현재 한 번에 한 장만 지원하므로 단일 파일 입력으로 UI 를 맞춘다.
+        {% endcomment %}
         <div class="ah-formsection">
           <h3 class="text-title-sm">제품 이미지</h3>
           <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
Django 인라인 주석 {# #} 은 한 줄만 인식돼, 여러 줄로 쓰면 주석 처리가 안 되고 텍스트가 그대로 렌더된다. {% comment %} 블록으로 교체.
- _banner_card.html: 배너 카드 좌측 순번 옆에 주석 문구 노출되던 것 수정
- product_list.html: 제품 이미지 섹션 위 동일 패턴 수정
<!-- A clear and concise description about the feature -->

## 이슈
close #233 
<!-- Add a issues that referenced this pull request -->
