### PR TITLE
feat(be): 배너 수정 모달 상세 이미지 추가 "+" 버튼·선택 즉시 추가(#242)

### DIFF
--- a/products/templates/admin_home/banner_list.html
+++ b/products/templates/admin_home/banner_list.html
@@ -196,6 +196,21 @@
     cursor: pointer;
   }
   .ah-detail-add { display: flex; align-items: flex-end; gap: var(--space-2); flex-wrap: wrap; }
+  /* 상세 이미지 추가 "+" 버튼 — 클릭 시 파일 선택 → 즉시 추가 */
+  .ah-addbtn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px dashed var(--glass-border-strong);
+    border-radius: var(--radius-md);
+    background: var(--glass-bg);
+    color: var(--text-on-glass);
+    cursor: pointer;
+    transition: background var(--transition-base);
+  }
+  .ah-addbtn:hover, .ah-addbtn:focus-within { background: var(--glass-bg-strong); }
+  .ah-addbtn__plus { font-size: var(--fs-text-lg); line-height: 1; color: var(--glass-highlight); }
 
   /* 수정 모달 레이아웃 — 섹션 구획 + 썸네일 교체 행 */
   .ah-edit-section { padding-top: var(--space-3); border-top: 1px solid var(--glass-border); }
@@ -597,6 +612,15 @@
       if (img) img.src = URL.createObjectURL(file); // 즉시 미리보기(제출 후 리다이렉트로 정리됨)
       var form = input.closest("form");
       if (form) form.submit(); // 기존 update action 재사용 → 저장·리다이렉트·토스트
+    });
+
+    /* ---- 수정 모달: 상세 이미지 추가 — 파일 선택 완료 시 즉시 추가(별도 버튼 없이) ---- */
+    document.addEventListener("change", function (e) {
+      var input = e.target.closest ? e.target.closest("[data-detail-add-input]") : null;
+      if (!input) return;
+      if (!input.files || !input.files.length) return;
+      var form = input.closest("form");
+      if (form) form.submit(); // 기존 detail_create action 재사용
     });
 
     // 파일 선택 → 배열에 누적 후 미리보기 갱신(input 은 비워 같은 파일 재선택 허용)

--- a/products/templates/admin_home/components/_banner_edit_modal.html
+++ b/products/templates/admin_home/components/_banner_edit_modal.html
@@ -65,18 +65,17 @@
         <p class="text-body-sm text-muted">등록된 상세 이미지가 없습니다.</p>
         {% endif %}
 
+        {# 상세 이미지 추가 — "+" 버튼 클릭 → 파일 선택 → 선택 완료 시 즉시 추가(자동 submit) #}
         <form method="post" enctype="multipart/form-data" class="ah-detail-add">
           {% csrf_token %}
           <input type="hidden" name="action" value="detail_create" />
           <input type="hidden" name="banner_id" value="{{ b.id }}" />
-          <div class="ah-field">
-            <label class="ah-label" for="banner-edit-detail-{{ b.id }}">
-              상세 이미지 추가 <span class="text-muted">(여러 장 선택 가능)</span>
-            </label>
-            <input class="ah-file" type="file" id="banner-edit-detail-{{ b.id }}"
-                   name="detail_image" accept="image/*" multiple required />
-          </div>
-          <button type="submit" class="btn btn-glass">추가</button>
+          <label class="ah-addbtn" title="상세 이미지 추가 (여러 장 선택 가능)">
+            <span class="ah-addbtn__plus" aria-hidden="true">＋</span>
+            <span class="text-body-sm">상세 이미지 추가</span>
+            <input class="ah-thumb-edit__input" type="file" name="detail_image" accept="image/*"
+                   multiple data-detail-add-input aria-label="상세 이미지 추가" />
+          </label>
         </form>
       </section>
 


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
파일 입력+"추가" 버튼을 "+" 버튼(라벨 래핑 hidden 파일 입력) 하나로 축소.
클릭 시 파일 선택창이 열리고, 선택 완료(change) 시 별도 버튼 없이 자동 submit 되어 즉시 추가된다(기존 detail_create action 재사용, 다중 선택 유지).
<!-- A clear and concise description about the feature -->

## 이슈
close #242 
<!-- Add a issues that referenced this pull request -->
