### PR TITLE
fix: 어드민 드롭다운 옵션 흰 배경+흰 글씨로 안 보이던 문제 수정(#251)

### DIFF
--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -516,6 +516,15 @@
 }
 .ah-textarea { min-height: calc(var(--space-8) * 2); resize: vertical; }
 
+/* 드롭다운 옵션 목록 — 네이티브 <option> 은 OS 기본 흰 배경으로 렌더되므로,
+   .ah-select 의 흰 글씨(--text-on-glass)를 그대로 상속하면 흰 배경+흰 글씨로 안 보인다.
+   옵션 목록에는 대비되는 어두운 글씨 + 밝은 배경을 명시한다(크롬/사파리/파폭 공통). */
+.ah-select option,
+.ah-select optgroup {
+  color: var(--text-default);
+  background: var(--surface);
+}
+
 .ah-input:focus,
 .ah-select:focus,
 .ah-textarea:focus {


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
.ah-select 의 흰 글씨(--text-on-glass)를 네이티브 <option> 목록이 상속하면 OS 기본 흰 배경과 겹쳐 안 보인다. option/optgroup 에 어두운 글씨(--text-default)
+ 밝은 배경(--surface)을 명시해 대비 확보(admin_home 전체 드롭다운 공통).
<!-- A clear and concise description about the feature -->

## 이슈
close #251 
<!-- Add a issues that referenced this pull request -->
