### PR TITLE
feat: 제품 추가 모달 레이아웃을 상세 모달과 통일 — 2탭(#259)

### DIFF
--- a/products/templates/admin_home/product_list.html
+++ b/products/templates/admin_home/product_list.html
@@ -26,98 +26,109 @@
       <button type="button" class="ah-modal__close" data-modal-close aria-label="닫기">&times;</button>
     </div>
     <div class="ah-modal__body">
+      {# 상세 모달과 동일한 2탭(기본정보·카테고리 / 성분). 패널은 한 form 안에 있어 저장 시 전체 전송 #}
+      <div class="ah-tabs" role="tablist" aria-label="제품 정보 구분" data-ptabs>
+        <button type="button" class="ah-tab is-active" data-ptab="basic" role="tab">기본 정보 · 카테고리</button>
+        <button type="button" class="ah-tab" data-ptab="ingredients" role="tab">성분</button>
+      </div>
       <form method="post" enctype="multipart/form-data" class="ah-stack">
         {% csrf_token %}
         <input type="hidden" name="action" value="create" />
 
-        <div class="ah-grid">
-          <div class="ah-field">
-            <label class="ah-label" for="pc-name">제품명</label>
-            <input class="ah-input" type="text" id="pc-name" name="name" required />
-          </div>
-          <div class="ah-field">
-            <label class="ah-label" for="pc-company">제조사</label>
-            <input class="ah-input" type="text" id="pc-company" name="company" required />
-          </div>
-          <div class="ah-field">
-            <label class="ah-label" for="pc-type">제품 유형</label>
-            <input class="ah-input" type="text" id="pc-type" name="productType"
-                   placeholder="예: 건강기능식품" required />
-          </div>
-          <div class="ah-field">
-            <label class="ah-label" for="pc-coupang">쿠팡 링크</label>
-            <input class="ah-input" type="text" id="pc-coupang" name="coupang" placeholder="https://..." />
-          </div>
-        </div>
-
-        <div class="ah-field">
-          <label class="ah-label" for="pc-images">제품 이미지</label>
-          <input class="ah-input" type="file" id="pc-images" name="image_files" multiple accept="image/*" />
-        </div>
-
-        {# 성분 — 성분 선택 + 용량, 행 단위로 함께 추가/삭제된다(ingredient_ids[] / amounts[] 인덱스 대응) #}
-        <div class="ah-formsection">
-          <h3 class="text-title-sm">성분</h3>
-          <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
-            성분을 선택하고 용량을 입력합니다.
-          </p>
-        </div>
-        <div class="ah-listedit" data-row-group>
-          <div class="ah-listedit__rows" data-row-list>
-            <div class="ah-listedit__row" data-row>
-              <select class="ah-select" name="ingredient_ids[]" aria-label="성분 선택">
-                <option value="">성분 선택</option>
-                {% for ing in ingredients %}
-                <option value="{{ ing.id }}">{{ ing.name }}</option>
-                {% endfor %}
-              </select>
-              <input class="ah-input" type="text" name="amounts[]" placeholder="예: 1000mg" aria-label="용량" />
-              <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
+        {# ── 탭① 기본 정보 · 카테고리 ── #}
+        <div data-ptab-panel="basic">
+          <div class="ah-grid">
+            <div class="ah-field">
+              <label class="ah-label" for="pc-name">제품명</label>
+              <input class="ah-input" type="text" id="pc-name" name="name" required />
+            </div>
+            <div class="ah-field">
+              <label class="ah-label" for="pc-company">제조사</label>
+              <input class="ah-input" type="text" id="pc-company" name="company" required />
+            </div>
+            <div class="ah-field">
+              <label class="ah-label" for="pc-type">제품 유형</label>
+              <input class="ah-input" type="text" id="pc-type" name="productType"
+                     placeholder="예: 건강기능식품" required />
+            </div>
+            <div class="ah-field">
+              <label class="ah-label" for="pc-coupang">쿠팡 링크</label>
+              <input class="ah-input" type="text" id="pc-coupang" name="coupang" placeholder="https://..." />
             </div>
           </div>
-          <button type="button" class="btn btn-glass" data-row-add>+ 성분 추가</button>
+
+          <div class="ah-field">
+            <label class="ah-label" for="pc-images">제품 이미지</label>
+            <input class="ah-input" type="file" id="pc-images" name="image_files" multiple accept="image/*" />
+          </div>
+
+          {# 소분류 카테고리 #}
+          <div class="ah-formsection">
+            <h3 class="text-title-sm">카테고리(소분류)</h3>
+          </div>
+          <div class="ah-listedit" data-row-group>
+            <div class="ah-listedit__rows" data-row-list>
+              <div class="ah-listedit__row" data-row>
+                <select class="ah-select" name="category_ids[]" aria-label="소분류 선택">
+                  <option value="">소분류 선택</option>
+                  {% for sc in small_categories %}
+                  <option value="{{ sc.id }}">
+                    {{ sc.middle_category.big_category.category }} &gt;
+                    {{ sc.middle_category.category }} &gt;
+                    {{ sc.category }}
+                  </option>
+                  {% endfor %}
+                </select>
+                <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
+              </div>
+            </div>
+            <button type="button" class="btn btn-glass" data-row-add>+ 카테고리 추가</button>
+          </div>
         </div>
 
-        {# 기타 원료 #}
-        <div class="ah-formsection">
-          <h3 class="text-title-sm">기타 원료</h3>
-        </div>
-        <div class="ah-listedit" data-row-group>
-          <div class="ah-listedit__rows" data-row-list>
-            <div class="ah-listedit__row" data-row>
-              <select class="ah-select" name="other_ingredient_ids[]" aria-label="기타 원료 선택">
-                <option value="">기타 원료 선택</option>
-                {% for oi in other_ingredients %}
-                <option value="{{ oi.id }}">{{ oi.name }}</option>
-                {% endfor %}
-              </select>
-              <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
-            </div>
+        {# ── 탭② 성분 (성분 + 기타 원료) ── #}
+        <div data-ptab-panel="ingredients" hidden>
+          {# 성분 — 성분 선택 + 용량, 행 단위로 함께 추가/삭제된다(ingredient_ids[] / amounts[] 인덱스 대응) #}
+          <div class="ah-formsection">
+            <h3 class="text-title-sm">성분</h3>
+            <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
+              성분을 선택하고 용량을 입력합니다.
+            </p>
           </div>
-          <button type="button" class="btn btn-glass" data-row-add>+ 기타 원료 추가</button>
-        </div>
+          <div class="ah-listedit" data-row-group>
+            <div class="ah-listedit__rows" data-row-list>
+              <div class="ah-listedit__row" data-row>
+                <select class="ah-select" name="ingredient_ids[]" aria-label="성분 선택">
+                  <option value="">성분 선택</option>
+                  {% for ing in ingredients %}
+                  <option value="{{ ing.id }}">{{ ing.name }}</option>
+                  {% endfor %}
+                </select>
+                <input class="ah-input" type="text" name="amounts[]" placeholder="예: 1000mg" aria-label="용량" />
+                <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
+              </div>
+            </div>
+            <button type="button" class="btn btn-glass" data-row-add>+ 성분 추가</button>
+          </div>
 
-        {# 소분류 카테고리 #}
-        <div class="ah-formsection">
-          <h3 class="text-title-sm">카테고리(소분류)</h3>
-        </div>
-        <div class="ah-listedit" data-row-group>
-          <div class="ah-listedit__rows" data-row-list>
-            <div class="ah-listedit__row" data-row>
-              <select class="ah-select" name="category_ids[]" aria-label="소분류 선택">
-                <option value="">소분류 선택</option>
-                {% for sc in small_categories %}
-                <option value="{{ sc.id }}">
-                  {{ sc.middle_category.big_category.category }} &gt;
-                  {{ sc.middle_category.category }} &gt;
-                  {{ sc.category }}
-                </option>
-                {% endfor %}
-              </select>
-              <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
-            </div>
+          {# 기타 원료 #}
+          <div class="ah-formsection">
+            <h3 class="text-title-sm">기타 원료</h3>
           </div>
-          <button type="button" class="btn btn-glass" data-row-add>+ 카테고리 추가</button>
+          <div class="ah-listedit" data-row-group>
+            <div class="ah-listedit__rows" data-row-list>
+              <div class="ah-listedit__row" data-row>
+                <select class="ah-select" name="other_ingredient_ids[]" aria-label="기타 원료 선택">
+                  <option value="">기타 원료 선택</option>
+                  {% for oi in other_ingredients %}
+                  <option value="{{ oi.id }}">{{ oi.name }}</option>
+                  {% endfor %}
+                </select>
+                <button type="button" class="btn btn-glass" data-row-remove>삭제</button>
+              </div>
+            </div>
+            <button type="button" class="btn btn-glass" data-row-add>+ 기타 원료 추가</button>
+          </div>
         </div>
 
         <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
@@ -738,6 +749,23 @@
       });
       scope.querySelectorAll("[data-ptab-panel]").forEach(function (p) {
         p.hidden = p.getAttribute("data-ptab-panel") !== name;
+      });
+    });
+
+    // 추가 모달 열 때 첫 탭(기본 정보)으로 초기화(이전에 성분 탭에서 닫았어도 리셋)
+    document.addEventListener("click", function (e) {
+      var op = e.target.closest
+        ? e.target.closest('[data-modal-open="product-create-modal"]')
+        : null;
+      if (!op) return;
+      var modal = document.getElementById("product-create-modal");
+      var body = modal && modal.querySelector(".ah-modal__body");
+      if (!body) return;
+      body.querySelectorAll("[data-ptab]").forEach(function (t) {
+        t.classList.toggle("is-active", t.getAttribute("data-ptab") === "basic");
+      });
+      body.querySelectorAll("[data-ptab-panel]").forEach(function (p) {
+        p.hidden = p.getAttribute("data-ptab-panel") !== "basic";
       });
     });
   })();


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
제품 추가 모달(#product-create-modal)을 상세 모달과 동일한 2탭으로 재구성
① 기본 정보·이미지·카테고리 
② 성분·기타원료. 한 form 안에 전체 필드 유지(create 로직 그대로), 상세 모달의 .ah-tabs/data-ptab 패턴·전환 JS 재사용, 열릴 때 첫 탭 초기화.

<!-- A clear and concise description about the feature -->

## 이슈
close #259 
<!-- Add a issues that referenced this pull request -->
