### PR TITLE
fix: 제품 2탭 모달 — 숨겨진 탭의 필수입력으로 저장이 막히던 문제 수정(#260)

### DIFF
--- a/products/templates/admin_home/product_list.html
+++ b/products/templates/admin_home/product_list.html
@@ -768,6 +768,29 @@
         p.hidden = p.getAttribute("data-ptab-panel") !== "basic";
       });
     });
+
+    // 숨겨진 탭의 필수 입력으로 저장이 조용히 막히는 문제 방지:
+    // 제출 시 required 가 비어 있으면 브라우저가 'invalid' 를 쏘는데, 그 필드가 hidden 패널에
+    // 있으면 포커스/안내가 안 된다. 캡처 단계에서 받아 해당 필드의 탭으로 먼저 전환해준다.
+    // ('invalid' 는 버블링 안 하므로 document 캡처로 수신)
+    document.addEventListener(
+      "invalid",
+      function (e) {
+        var field = e.target;
+        if (!field || !field.closest) return;
+        var panel = field.closest("[data-ptab-panel]");
+        var scope = field.closest(".ah-modal__body");
+        if (!panel || !scope || !panel.hidden) return;
+        var name = panel.getAttribute("data-ptab-panel");
+        scope.querySelectorAll("[data-ptab]").forEach(function (t) {
+          t.classList.toggle("is-active", t.getAttribute("data-ptab") === name);
+        });
+        scope.querySelectorAll("[data-ptab-panel]").forEach(function (p) {
+          p.hidden = p.getAttribute("data-ptab-panel") !== name;
+        });
+      },
+      true
+    );
   })();
 
   // 제품 이미지 호버 교체 — 파일 선택 시 미리보기 교체 + 해당 이미지 삭제 체크(기존 삭제+새 파일 = 교체).


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
탭②(성분)에서 제출 시 탭①의 빈 required(name/company/productType)가 display:none 안이라 브라우저가 포커스/안내를 못 해 저장이 조용히 막히던 문제. document 캡처로 'invalid' 를 받아 해당 필드가 있는 탭으로 먼저 전환 → 브라우저가 정상 안내(추가·수정 모달 공통).
<!-- A clear and concise description about the feature -->

## 이슈
close #260 
<!-- Add a issues that referenced this pull request -->
