### PR TITLE
refactor: 성분 가이드 범위 재조정 — 효과·부작용은 원료 탭, 가이드는 핵심포인트·출처만(#261)

### DIFF
--- a/products/admin_home_views.py
+++ b/products/admin_home_views.py
@@ -1082,20 +1082,25 @@ def ingredient_list(request):
             if length_error:
                 messages.error(request, length_error)
                 return redirect("admin_home_ingredient")
-            # 효과·부작용·핵심 포인트·출처(성분 가이드)는 전용 페이지(ingredient_guide)에서
-            # 편집한다. 여기서는 기본 필드만 저장해 가이드 데이터를 덮어쓰지 않는다.
+            # 기본 필드 + 효과·부작용(이 원료 모달에서 편집).
+            # 핵심 포인트·출처(IngredientGuide)는 성분 가이드 전용 페이지에서만 다뤄
+            # 여기서 건드리지 않는다(덮어쓰기 방지).
             ingredient.name = name
             ingredient.mainIngredient = (
                 request.POST.get("mainIngredient", "").strip() or None
             )
             ingredient.minRecommended = min_recommended or None
             ingredient.maxRecommended = max_recommended or None
+            ingredient.effect = _parse_json_list(request.POST.get("effect"))
+            ingredient.sideEffect = _parse_json_list(request.POST.get("sideEffect"))
             ingredient.save(
                 update_fields=[
                     "name",
                     "mainIngredient",
                     "minRecommended",
                     "maxRecommended",
+                    "effect",
+                    "sideEffect",
                 ]
             )
             messages.success(request, f'"{name}" 성분 정보가 저장되었습니다.')
@@ -1142,20 +1147,18 @@ def ingredient_list(request):
 
 
 def ingredient_guide(request):
-    """성분 가이드 — 성분별 효과·부작용(Ingredient) + 핵심 포인트·출처(IngredientGuide 1:1).
+    """성분 가이드 — 성분별 핵심 포인트·출처(IngredientGuide 1:1) 전용 편집 페이지.
 
-    내용이 많아 원료(ingredient_list) 모달에서 분리한 전용 페이지. 성분을 선택해
-    네 가지 JSON 리스트를 편집한다. 저장 시 IngredientGuide 가 없으면 생성한다.
+    핵심 포인트·출처만 다룬다(효과·부작용은 원료 ingredient_list 모달에서 편집).
+    저장 시 IngredientGuide 가 없으면 생성한다.
     """
     if request.method == "POST" and request.POST.get("action") == "update":
         ingredient = _get_ingredient(request)
         if ingredient is None:
             return redirect("admin_home_guide")
         with transaction.atomic():
-            ingredient.effect = _parse_json_list(request.POST.get("effect"))
-            ingredient.sideEffect = _parse_json_list(request.POST.get("sideEffect"))
-            ingredient.save(update_fields=["effect", "sideEffect"])
             # IngredientGuide(1:1) — 없으면 만들고 있으면 갱신한다.
+            # 효과·부작용(Ingredient)은 여기서 건드리지 않는다(원료 모달 담당).
             guide, _ = IngredientGuide.objects.get_or_create(ingredient=ingredient)
             guide.keyPoints = _parse_json_list(request.POST.get("keyPoints"))
             guide.sources = _parse_json_list(request.POST.get("sources"))

--- a/products/templates/admin_home/ingredient_guide.html
+++ b/products/templates/admin_home/ingredient_guide.html
@@ -27,48 +27,10 @@
         <input type="hidden" name="action" value="update" />
         <input type="hidden" name="id" value="{{ ing.id }}" />
 
-        <div class="ah-grid">
-          {# 효과 (JSON 리스트) #}
-          <div class="ah-field">
-            <label class="ah-label">효과</label>
-            <div class="ah-listedit" data-listedit>
-              <div class="ah-listedit__rows">
-                {% for e in ing.effect %}
-                <div class="ah-listedit__row">
-                  <textarea class="ah-textarea text-body" data-listedit-item
-                            rows="2" aria-label="효과 항목">{{ e }}</textarea>
-                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                </div>
-                {% endfor %}
-              </div>
-              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-              <input type="hidden" name="effect" data-listedit-target />
-            </div>
-          </div>
-
-          {# 부작용 (JSON 리스트) #}
-          <div class="ah-field">
-            <label class="ah-label">부작용</label>
-            <div class="ah-listedit" data-listedit>
-              <div class="ah-listedit__rows">
-                {% for s in ing.sideEffect %}
-                <div class="ah-listedit__row">
-                  <textarea class="ah-textarea text-body" data-listedit-item
-                            rows="2" aria-label="부작용 항목">{{ s }}</textarea>
-                  <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
-                </div>
-                {% endfor %}
-              </div>
-              <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
-              <input type="hidden" name="sideEffect" data-listedit-target />
-            </div>
-          </div>
-        </div>
-
         <div class="ah-formsection">
           <h3 class="text-title-sm">성분 가이드</h3>
           <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
-            성분별 핵심 포인트와 출처를 관리합니다. (저장 시 없으면 자동 생성)
+            성분별 핵심 포인트와 출처를 관리합니다(효과·부작용은 원료 메뉴에서 편집). 저장 시 없으면 자동 생성.
           </p>
         </div>
 
@@ -125,7 +87,7 @@
       성분 목록 <span class="text-muted">({{ ingredients|length }})</span>
     </h2>
     <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
-      성분을 클릭해 효과·부작용·핵심 포인트·출처를 편집합니다. 기본 정보(이름·권장량 등)는 원료 메뉴에서 관리합니다.
+      성분을 클릭해 핵심 포인트·출처를 편집합니다. 효과·부작용·기본 정보(이름·권장량 등)는 원료 메뉴에서 관리합니다.
     </p>
   </div>
 
@@ -142,7 +104,7 @@
         {% endif %}
       </div>
       <div class="ah-record__actions">
-        {% if ing.effect or ing.sideEffect or ing.guide.keyPoints or ing.guide.sources %}
+        {% if ing.guide.keyPoints or ing.guide.sources %}
         <span class="ah-guideflag ah-guideflag--on text-body-sm" title="작성된 가이드 있음">● 작성됨</span>
         {% else %}
         <span class="ah-guideflag ah-guideflag--off text-body-sm" title="가이드 미작성">○ 미작성</span>

--- a/products/templates/admin_home/ingredient_list.html
+++ b/products/templates/admin_home/ingredient_list.html
@@ -109,13 +109,44 @@
             </div>
           </div>
 
-          {# 효과·부작용·핵심 포인트·출처는 좌측 '성분 가이드' 메뉴에서 편집한다(내용 분리). #}
-          <div class="ah-formsection">
-            <h3 class="text-title-sm">성분 가이드</h3>
-            <p class="text-caption" style="color: var(--glass-highlight); margin-top: var(--space-1);">
-              효과·부작용·핵심 포인트·출처는 좌측 <strong>성분 가이드</strong> 메뉴에서 편집합니다.
-            </p>
+          {# 효과·부작용 (JSON 리스트) — 이 원료 모달에서 편집. 핵심 포인트·출처는 성분 가이드 메뉴. #}
+          <div class="ah-grid">
+            <div class="ah-field">
+              <label class="ah-label">효과</label>
+              <div class="ah-listedit" data-listedit>
+                <div class="ah-listedit__rows">
+                  {% for e in ing.effect %}
+                  <div class="ah-listedit__row">
+                    <textarea class="ah-textarea text-body" data-listedit-item
+                              rows="2" aria-label="효과 항목">{{ e }}</textarea>
+                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                  </div>
+                  {% endfor %}
+                </div>
+                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+                <input type="hidden" name="effect" data-listedit-target />
+              </div>
+            </div>
+            <div class="ah-field">
+              <label class="ah-label">부작용</label>
+              <div class="ah-listedit" data-listedit>
+                <div class="ah-listedit__rows">
+                  {% for s in ing.sideEffect %}
+                  <div class="ah-listedit__row">
+                    <textarea class="ah-textarea text-body" data-listedit-item
+                              rows="2" aria-label="부작용 항목">{{ s }}</textarea>
+                    <button type="button" class="btn btn-glass" data-listedit-remove>삭제</button>
+                  </div>
+                  {% endfor %}
+                </div>
+                <button type="button" class="btn btn-glass" data-listedit-add>+ 줄 추가</button>
+                <input type="hidden" name="sideEffect" data-listedit-target />
+              </div>
+            </div>
           </div>
+          <p class="text-caption" style="color: var(--glass-highlight);">
+            핵심 포인트·출처는 좌측 <strong>성분 가이드</strong> 메뉴에서 관리합니다.
+          </p>
 
           <div style="display:flex; gap:var(--space-2); justify-content:flex-end; margin-top:var(--space-2);">
             <button type="button" class="btn btn-glass" data-modal-close>취소</button>


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
#241 부분 되돌림.
- 원료(기능성) 모달에 효과·부작용 편집 복원(ingredient_list update 에 effect/sideEffect 저장).
- 성분 가이드 페이지는 핵심 포인트·출처만 편집(ingredient_guide update 에서 effect/sideEffect 저장 제거).
- 가이드 작성 여부 플래그를 keyPoints/sources 유무로만 판단.
<!-- A clear and concise description about the feature -->

## 이슈
close #261 
<!-- Add a issues that referenced this pull request -->
