### PR TITLE
feat: 맨 위로 가기 플로팅 버튼 추가(#262)

### DIFF
--- a/products/static/admin_home/css/components.css
+++ b/products/static/admin_home/css/components.css
@@ -882,3 +882,51 @@ body.ah-modal-open { overflow: hidden; }
   color: var(--glass-highlight);
   padding: var(--space-1) var(--space-2);
 }
+
+/* =========================================================
+   맨 위로 가기 플로팅 버튼 — 긴 목록에서 스크롤 시 우 하단 노출
+   ========================================================= */
+.ah-to-top {
+  position: fixed;
+  right: var(--space-4);
+  bottom: var(--space-4);
+  z-index: 30; /* 토프바(20) 위, 모달(--z-modal) 아래 */
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg-strong);
+  -webkit-backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--blur-md)) saturate(var(--glass-saturate));
+  box-shadow: var(--shadow-glass), var(--shadow-inset-highlight);
+  color: var(--text-on-glass);
+  font-size: var(--fs-text-lg);
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity var(--transition-base), transform var(--transition-base),
+    visibility var(--transition-base);
+}
+.ah-to-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: none;
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ah-to-top {
+    background: var(--glass-bg-fallback);
+    color: var(--text-default);
+    border-color: var(--color-gray-200);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ah-to-top {
+    transform: none;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+  }
+}

--- a/products/static/admin_home/js/interactions.js
+++ b/products/static/admin_home/js/interactions.js
@@ -179,11 +179,34 @@
     });
   }
 
+  /* -----------------------------------------------------------
+     맨 위로 가기 버튼 — .ah-content-scroll 이 일정 이상 스크롤되면 노출,
+     클릭 시 맨 위로. 셸 요소라 한 번만 배선(_ahToTopWired).
+     ----------------------------------------------------------- */
+  function initToTop() {
+    if (document._ahToTopWired) return;
+    var btn = document.getElementById("ah-to-top");
+    var scroller = document.querySelector(".ah-content-scroll");
+    if (!btn || !scroller) return;
+    document._ahToTopWired = "1";
+
+    var THRESHOLD = 240;
+    function onScroll() {
+      btn.classList.toggle("is-visible", scroller.scrollTop > THRESHOLD);
+    }
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    btn.addEventListener("click", function () {
+      scroller.scrollTo({ top: 0, behavior: reduceMotion ? "auto" : "smooth" });
+    });
+    onScroll();
+  }
+
   function init() {
     document.querySelectorAll(".glass-nav").forEach(wireNav);
     initGlassSheen();
     initModals();
     initSidebarToggle();
+    initToTop();
   }
 
   // 창 크기 변경 시 모든 nav 인디케이터 위치 재계산 (전역에 한 번만 바인딩)

--- a/products/templates/admin_home/base.html
+++ b/products/templates/admin_home/base.html
@@ -113,6 +113,11 @@
     </div>
   </div>
 
+  {# 맨 위로 가기 — 스크롤이 일정 이상일 때만 노출(interactions.js 가 배선). 긴 목록 페이지용 #}
+  <button type="button" class="ah-to-top" id="ah-to-top" aria-label="맨 위로">
+    <span aria-hidden="true">↑</span>
+  </button>
+
   {# 디자인 시스템 인터랙션 스크립트 #}
   <script src="{% static 'admin_home/js/reveal.js' %}" defer></script>
   <script src="{% static 'admin_home/js/interactions.js' %}" defer></script>


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
우 하단 플로팅 버튼 — .ah-content-scroll 이 임계치 이상 스크롤되면 노출, 클릭 시 맨 위로. 셸(base.html)에 두어 긴 목록 페이지(성분가이드·제품·원료 등)에서 공통 사용.
글래스 토큰·컴포넌트, prefers-reduced-motion 존중, interactions.js 가 한 번만 배선.
<!-- A clear and concise description about the feature -->

## 이슈
close #262 
<!-- Add a issues that referenced this pull request -->
